### PR TITLE
Add Carbon Ads to the footer of each demo example

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,8 @@
     <div class="carbonads-wrapper">
       <script src="//cdn.carbonads.com/carbon.js?zoneid=1673&serve=C6AILKT&placement=sweetalert2githubio" id="_carbonads_js" async></script>
       <link rel="stylesheet" href="./styles/carbon-ads.css">
+      <script src="//m.servedby-buysellads.com/monetization.js"></script>
+      <div class="bsa-cpc"></div>
     </div>
     <div class="stats mobile-hidden">
       Current version: <a href="https://github.com/sweetalert2/sweetalert2/releases" id="current-version" aria-label="Current version "></a> ●
@@ -1379,6 +1381,7 @@ swal({
       timer: 5000,
       onOpen: () => {
         swal.showLoading()
+        $('.bsa-cpc').appendTo('.swal2-modal')
       }
     }).then((result) => {
       if (result.dismiss === 'timer') {
@@ -1788,6 +1791,19 @@ swal({
     var type = $(e.currentTarget).attr('class').slice(5)
     swal(type + '!', '', type)
   })
+
+  swal.setDefaults({
+    onOpen: () => $('.bsa-cpc').appendTo('.swal2-modal'),
+    onClose: () => $('.bsa-cpc').appendTo('.carbonads-wrapper')
+  })
+
+  if(typeof _bsa !== 'undefined' && _bsa) {
+    _bsa.init('default', 'CKYDK5QE', 'placement:sweetalert2githubio', {
+      target: '.bsa-cpc',
+      align: 'horizontal',
+      disable_css: 'true'
+    });
+  }
 
   // Google Analytics
   /* eslint-disable */

--- a/styles/carbon-ads.css
+++ b/styles/carbon-ads.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 .carbonads-wrapper {
   height: 126px; }
   .carbonads-wrapper > div {
@@ -39,3 +40,57 @@
       bottom: 0;
       display: block;
       font-size: 11px; }
+  .carbonads-wrapper .bsa-cpc {
+    display: none; }
+
+.bsa-cpc #_default_ {
+  position: relative;
+  margin-top: 20px;
+  padding: 10px 1em 0;
+  border-top: solid 1px #f2f4f6;
+  text-align: left;
+  font-size: 14px;
+  line-height: 1.5; }
+
+.bsa-cpc .default-ad {
+  display: none; }
+
+.bsa-cpc ._default_ {
+  display: inline;
+  overflow: hidden;
+  line-height: 1; }
+  .bsa-cpc ._default_ > * {
+    vertical-align: middle; }
+
+.bsa-cpc a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 500; }
+  .bsa-cpc a:hover {
+    color: #87d25f;
+    text-decoration: none; }
+
+.bsa-cpc .default-image {
+  display: none; }
+
+.bsa-cpc .default-title {
+  position: relative;
+  margin-left: 8px; }
+  .bsa-cpc .default-title::before {
+    position: relative;
+    top: -1px;
+    left: -8px;
+    padding: 2px 5px;
+    border: solid 1px #87d25f;
+    border-radius: 2px;
+    color: #87d25f;
+    content: 'Sponsor';
+    text-transform: uppercase;
+    font-size: 10px;
+    line-height: 1; }
+  .bsa-cpc .default-title::after {
+    content: ' — '; }
+
+.bsa-cpc .default-title,
+.bsa-cpc .default-description {
+  display: inline; }

--- a/styles/carbon-ads.scss
+++ b/styles/carbon-ads.scss
@@ -55,4 +55,77 @@
       font-size: 11px;
     }
   }
+
+  .bsa-cpc {
+    display: none;
+  }
+}
+
+.bsa-cpc {
+  #_default_ {
+    position: relative;
+    margin-top: 20px;
+    padding: 10px 1em 0;
+    border-top: solid 1px $athens;
+    text-align: left;
+    font-size: 14px;
+    line-height: 1.5;
+  }
+
+  .default-ad {
+    display: none;
+  }
+
+  ._default_ {
+    display: inline;
+    overflow: hidden;
+    line-height: 1;
+
+    > * {
+      vertical-align: middle;
+    }
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+    font-weight: 500;
+
+    &:hover {
+      color: $pastel-green;
+      text-decoration: none;
+    }
+  }
+
+  .default-image {
+    display: none;
+  }
+
+  .default-title {
+    position: relative;
+    margin-left: 8px;
+
+    &::before {
+      position: relative;
+      top: -1px;
+      left: -8px;
+      padding: 2px 5px;
+      border: solid 1px $pastel-green;
+      border-radius: 2px;
+      color: $pastel-green;
+      content: 'Sponsor';
+      text-transform: uppercase;
+      font-size: 10px;
+      line-height: 1;
+    }
+
+    &::after {
+      content: ' — ';
+    }
+  }
+
+  .default-title,
+  .default-description {
+    display: inline;
+  }
 }


### PR DESCRIPTION
As you maybe noticed, there's the Carbon ads block in the header:

![image](https://user-images.githubusercontent.com/6059356/34640620-e52e38c4-f2fe-11e7-9c68-f0e433e99d4e.png)

[Carbon](https://carbonads.net/) is the invite-only ad network connecting highly qualified audiences with highly relevant services, products, and brands. 

Yesterday I got the offer from them to improve the integration by adding textual ads to the footer of each modal:
 
![image](https://user-images.githubusercontent.com/6059356/34640604-7410a622-f2fe-11e7-958e-b93dbc349dd4.png)

If someone of you guys has the strong disagreement with showing ads this way, please let me know.

By doing this I will be able to say hi via PayPal to all of you more often :) 
We spending our time on producing the high-quality product, and I believe that there should be at least some financial feedback from our good work.
  