### PR TITLE
Move from unreliable unpkg.com to jsdelivr.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,10 +38,10 @@
   <meta name="theme-color" content="#f2f4f6">
 
   <!-- Include a polyfill for ES6 Promises (optional) for IE11, UC Browser and Android browser support -->
-  <!-- <script src="https://unpkg.com/promise-polyfill"></script> -->
+  <!-- <script src="https://cdn.jsdelivr.net/npm/promise-polyfill"></script> -->
 
   <!-- This is what you need -->
-  <script src="https://unpkg.com/sweetalert2"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sweetalert2"></script>
   <!--.......................-->
 </head>
 
@@ -462,7 +462,6 @@ swal.queue([{
     <pre class="center"><code>$ bower install sweetalert2</code></pre>
     <p>
       Or download from CDN:
-      <a href="https://unpkg.com/sweetalert2" target="_blank" rel="noopener" class="nowrap">unpkg.com/sweetalert2 <i class="fa fa-external-link"></i></a> |
       <a href="https://cdn.jsdelivr.net/npm/sweetalert2" target="_blank" rel="noopener" class="nowrap">cdn.jsdelivr.net/npm/sweetalert2 <i class="fa fa-external-link"></i></a>
     </p>
   </div>
@@ -475,7 +474,7 @@ swal.queue([{
       <pre>
 <code>&lt;script src="sweetalert2.all.min.js"&gt;&lt;/script&gt;
 &lt;!-- Optional: include a polyfill for ES6 Promises for IE11 and Android browser --&gt;
-&lt;script src="https://unpkg.com/promise-polyfill"&gt;&lt;/script&gt;</code></pre>
+&lt;script src="https://cdn.jsdelivr.net/npm/promise-polyfill"&gt;&lt;/script&gt;</code></pre>
       <p class="mobile-hidden">You can also include the stylesheet separately if desired:</p>
       <pre>
 <code>&lt;script src="sweetalert2.min.js"&gt;&lt;/script&gt;

--- a/js/bundle.js
+++ b/js/bundle.js
@@ -9889,7 +9889,7 @@ Array.from(document.querySelectorAll('pre.code-sample')).forEach(function (pre) 
   pre.addEventListener('click', function (e) {
     if (e.offsetY < 0) {
       var codepenValue = {
-        js_external: 'https://unpkg.com/sweetalert2;https://unpkg.com/promise-polyfill'
+        js_external: 'https://cdn.jsdelivr.net/npm/sweetalert2;https://cdn.jsdelivr.net/npm/promise-polyfill'
       };
       if (pre.getAttribute('data-codepen-html')) {
         codepenValue.html = pre.getAttribute('data-codepen-html');

--- a/js/main.js
+++ b/js/main.js
@@ -597,7 +597,7 @@ Array.from(document.querySelectorAll('pre.code-sample')).forEach(pre => {
   pre.addEventListener('click', (e) => {
     if (e.offsetY < 0) {
       const codepenValue = {
-        js_external: 'https://unpkg.com/sweetalert2;https://unpkg.com/promise-polyfill'
+        js_external: 'https://cdn.jsdelivr.net/npm/sweetalert2;https://cdn.jsdelivr.net/npm/promise-polyfill'
       }
       if (pre.getAttribute('data-codepen-html')) {
         codepenValue.html = pre.getAttribute('data-codepen-html')


### PR DESCRIPTION
Reason: 

- https://github.com/unpkg/unpkg.com/issues/115
- https://github.com/unpkg/unpkg.com/issues/117

jsdelivr isn't ideal as well (https://github.com/sweetalert2/sweetalert2.github.io/commit/63b376024bb586682423dccf296d08f974ca26bf), but at least it's not failing, so that's the best we have right now.