### PR TITLE
Added missing id for some examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
 
   <ul class="examples">
 
-    <li class="message">
+    <li class="message" id="message-example">
       <div class="ui">
         <p>A basic message</p>
         <button aria-label="Try me! Example: A basic message">Try me!</button>
@@ -140,7 +140,7 @@
       <pre class="code-sample"><code>Swal('Any fool can use a computer')</code></pre>
     </li>
 
-    <li class="title-text">
+    <li class="title-text" id="title-text-example">
       <div class="ui">
         <p>A title with a text under</p>
         <button aria-label="Try me! Example: A title with a text under">Try me!</button>
@@ -153,7 +153,7 @@
 )</code></pre>
     </li>
 
-    <li class="error">
+    <li class="error" id="error-example">
       <div class="ui">
         <p>A modal with a title, an error icon, a text, and a footer</p>
         <button aria-label="Try me! Example: A modal with a title, an error icon, a text, and a footer">Try me!</button>
@@ -298,7 +298,7 @@ swalWithBootstrapButtons({
 })</code></pre>
     </li>
 
-    <li class="custom-image">
+    <li class="custom-image" id="custom-image-example">
       <div class="ui">
         <p>A message with a custom image and CSS animation disabled</p>
         <button aria-label="Try me! Example: A message with a custom image and CSS animation disabled">Try me!</button>
@@ -315,7 +315,7 @@ swalWithBootstrapButtons({
 })</code></pre>
     </li>
 
-    <li class="custom-width-padding-background">
+    <li class="custom-width-padding-background" id="custom-width-padding-background">
       <div class="ui">
         <p>A message with custom width, padding, background and animated Nyan Cat</p>
         <button aria-label="Try me! Example: A message with custom width, padding and background">Try me!</button>
@@ -335,7 +335,7 @@ swalWithBootstrapButtons({
 })</code></pre>
     </li>
 
-    <li class="timer">
+    <li class="timer" id="timer-example">
       <div class="ui">
         <p>A message with auto close timer</p>
         <button aria-label="Try me! Example: A message with auto close timer">Try me!</button>


### PR DESCRIPTION
Some of the examples don't have `id` for `li` tag. This makes difficult to refer to specific example from external pages. 

For example the custom image example cannot be linked to using  URL such as: 

https://sweetalert2.github.io/#custom-image-example
