### PR TITLE
Changed style for divider bar from ::after to ::before

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -128,7 +128,7 @@ h3 {
   margin-top: 6em;
   text-align: center;
   position: relative; }
-  h3::after {
+  h3::before {
     content: '';
     background-color: #e2e5e8;
     height: .25em;
@@ -139,7 +139,7 @@ h3 {
     margin-top: -2em;
     border-radius: .125em; }
     @media all and (max-width: 768px) {
-      h3::after {
+      h3::before {
         width: auto;
         left: 1.25em;
         right: 1.25em;

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -162,7 +162,7 @@ h3 {
   text-align: center;
   position: relative;
 
-  &::after {
+  &::before {
     content: '';
     background-color: $porcelain;
     height: .25em;


### PR DESCRIPTION
Changing the style used to create the bar from `::after` to `::before` makes the bar being rendered before the title text and avoid the text to overflow over the bar when the it becomes too long. I also think that it makes sense to have this bar styled as `::before`, since it's supposed to be before the title. 

I checked on various screen size and i don't see any regression (i.e. the bars stay in the same positions they were when used with `::after`). 

This is how it looks like with the new implementation on small screens: 

![integration_new](https://user-images.githubusercontent.com/17089396/49800301-11e83e00-fd3f-11e8-8a66-b0a5e23b53df.png)


Close #45 