### PR TITLE
Fix `inputOptions`

### DIFF
--- a/index.html
+++ b/index.html
@@ -898,7 +898,7 @@ import 'sweetalert2/src/sweetalert2.scss'</code></pre>
       <tr id="input-options">
         <td><b>inputOptions</b></td>
         <td><i>{}</i></td>
-        <td>If <strong>input</strong> parameter is set to <strong>"select"</strong> or <strong>"radio"</strong>, you can provide options. Object keys will represent options values, object values will represent options text values.</td>
+        <td>If <strong>input</strong> parameter is set to <strong>"select"</strong> or <strong>"radio"</strong>, you can provide options. Can be a Map or a plain object, with keys that represent option values and values that represent option text, or a Promise that resolves with one of those types.</td>
       </tr>
       <tr id="input-auto-trim">
         <td><b>inputAutoTrim</b></td>

--- a/index.html
+++ b/index.html
@@ -897,7 +897,7 @@ import 'sweetalert2/src/sweetalert2.scss'</code></pre>
       </tr>
       <tr id="input-options">
         <td><b>inputOptions</b></td>
-        <td><i>{} <br> Map <br> Promise</i></td>
+        <td><i>{}</i></td>
         <td>If <strong>input</strong> parameter is set to <strong>"select"</strong> or <strong>"radio"</strong>, you can provide options. Object keys will represent options values, object values will represent options text values.</td>
       </tr>
       <tr id="input-auto-trim">


### PR DESCRIPTION
Seems that the current documentation is trying to express the accepted *types* for the option, in the place where it should express the *default*.