### PR TITLE
Remove slashes in Navigation

### DIFF
--- a/v10.html
+++ b/v10.html
@@ -54,23 +54,23 @@
 
 <body>
   <nav class="mobile-hidden">
-    <a href="/#examples"><span>Examples</span></a>
+    <a href="#examples"><span>Examples</span></a>
     <a href="/recipe-gallery" class="recipe-gallery"><span>Recipe Gallery</span></a>
-    <a href="/#download"><span>Installation</span></a>
-    <a href="/#usage"><span>Usage</span></a>
-    <a href="/#frameworks-integrations"><span>Integrations</span></a>
-    <a href="/#configuration" class="mobile-hidden"><span>Configuration</span></a>
-    <a href="/#declarative-templates" class="mobile-hidden"><span>Declarative templates</span></a>
-    <a href="/#handling-buttons"><span>Handling Buttons</span></a>
-    <a href="/#handling-dismissals"><span>Dismissals</span></a>
-    <a href="/#icons"><span>Icons</span></a>
-    <a href="/#input-types"><span>Input Types</span></a>
-    <a href="/#methods" class="mobile-hidden"><span>Methods</span></a>
-    <a href="/#collaborators"><span>Collaborators</span></a>
-    <a href="/#themes"><span>Themes</span></a>
-    <a href="/#donations" class="mobile-hidden"><span>Donations</span></a>
-    <a href="/#sponsors"><span>Sponsors</span></a>
-    <a href="/#nsfw-sponsors"><span>NSFW Sponsors</span></a>
+    <a href="#download"><span>Installation</span></a>
+    <a href="#usage"><span>Usage</span></a>
+    <a href="#frameworks-integrations"><span>Integrations</span></a>
+    <a href="#configuration" class="mobile-hidden"><span>Configuration</span></a>
+    <a href="#declarative-templates" class="mobile-hidden"><span>Declarative templates</span></a>
+    <a href="#handling-buttons"><span>Handling Buttons</span></a>
+    <a href="#handling-dismissals"><span>Dismissals</span></a>
+    <a href="#icons"><span>Icons</span></a>
+    <a href="#input-types"><span>Input Types</span></a>
+    <a href="#methods" class="mobile-hidden"><span>Methods</span></a>
+    <a href="#collaborators"><span>Collaborators</span></a>
+    <a href="#themes"><span>Themes</span></a>
+    <a href="#donations" class="mobile-hidden"><span>Donations</span></a>
+    <a href="#sponsors"><span>Sponsors</span></a>
+    <a href="#nsfw-sponsors"><span>NSFW Sponsors</span></a>
 
     <div class="theme-selector">
       <label>Theme:


### PR DESCRIPTION
Remove slashes to stay in v10 version.
Currently, always switches to v11 when you click a navigation link.