### PR TITLE
fix: add rel="sponsored nofollow" to paid sponsor and affiliate links

### DIFF
--- a/src/components/Partners.tsx
+++ b/src/components/Partners.tsx
@@ -22,7 +22,7 @@ export function Partners() {
 
   return (
     <div className="partner">
-      <a href={partner.link} target="_blank" rel="noreferrer noopener" tabIndex={-1}>
+      <a href={partner.link} target="_blank" rel="sponsored nofollow noreferrer noopener" tabIndex={-1}>
         <img src={partner.imageUrl} alt="" />
         <b>{partner.title}</b>
         <div className="description">{partner.description}</div>

--- a/src/components/Prtnr.tsx
+++ b/src/components/Prtnr.tsx
@@ -82,7 +82,13 @@ export function Prtnr() {
   const prtnr = prtnrs[Math.floor(Math.random() * prtnrs.length)]
 
   return (
-    <a className="prtnr-lg" href={prtnr.link} target="_blank" rel="noreferrer noopener" tabIndex={-1}>
+    <a
+      className="prtnr-lg"
+      href={prtnr.link}
+      target="_blank"
+      rel="sponsored nofollow noreferrer noopener"
+      tabIndex={-1}
+    >
       <img src={prtnr.imageUrl} />
 
       {prtnr.title}

--- a/src/components/Sponsors.tsx
+++ b/src/components/Sponsors.tsx
@@ -27,21 +27,26 @@ export function Sponsors() {
 
       <div className="sponsors">
         <div>
-          <a href="https://www.blueplenum.com/" target="_blank" rel="noopener" aria-label="BluePlenum">
+          <a
+            href="https://www.blueplenum.com/"
+            target="_blank"
+            rel="sponsored nofollow noopener"
+            aria-label="BluePlenum"
+          >
             <img src="/images/sponsors/blueplenum.jpg" alt="BluePlenum" />
             <br />
             BluePlenum
           </a>
         </div>
         <div>
-          <a href="https://kryptot.fi/" target="_blank" rel="noopener" aria-label="Kryptot">
+          <a href="https://kryptot.fi/" target="_blank" rel="sponsored nofollow noopener" aria-label="Kryptot">
             <img src="/images/sponsors/kryptot.png" alt="Kryptot" />
             <br />
             Kryptot
           </a>
         </div>
         <div>
-          <a href="https://www.inksonic.com/" target="_blank" rel="noopener" aria-label="InkSonic">
+          <a href="https://www.inksonic.com/" target="_blank" rel="sponsored nofollow noopener" aria-label="InkSonic">
             <img src="/images/sponsors/inksonic.png" alt="InkSonic" />
             <br />
             InkSonic
@@ -51,7 +56,7 @@ export function Sponsors() {
           <a
             href="https://bluehive.com/?utm_source=sweetalert2&utm_medium=sponsored&utm_campaign=listing"
             target="_blank"
-            rel="noopener"
+            rel="sponsored nofollow noopener"
             aria-label="Your Occupational Healthcare Hub"
           >
             <img src="/images/sponsors/bluehive.png" alt="Your Occupational Healthcare Hub" />
@@ -63,7 +68,7 @@ export function Sponsors() {
           <a
             href="https://ssmarket.net/buy-youtube-views"
             target="_blank"
-            rel="noopener"
+            rel="sponsored nofollow noopener"
             aria-label="Buy Youtube Views"
           >
             <img src="/images/sponsors/ssmarket.png" alt="Buy Youtube Views" />
@@ -72,28 +77,33 @@ export function Sponsors() {
           </a>
         </div>
         <div>
-          <a href="https://github.com/tiagostutz" target="_blank" rel="noopener" aria-label="Tiago de Oliveira Stutz">
+          <a
+            href="https://github.com/tiagostutz"
+            target="_blank"
+            rel="sponsored nofollow noopener"
+            aria-label="Tiago de Oliveira Stutz"
+          >
             <img src="https://avatars0.githubusercontent.com/u/3986989?s=200&v=4" alt="Tiago de Oliveira Stutz" />
             <br />
             Tiago de Oliveira Stutz
           </a>
         </div>
         <div>
-          <a href="https://istar.tips/" target="_blank" rel="noopener" aria-label="iStarTips">
+          <a href="https://istar.tips/" target="_blank" rel="sponsored nofollow noopener" aria-label="iStarTips">
             <img src="/images/sponsors/istartips.png" alt="iStarTips" />
             <br />
             iStarTips
           </a>
         </div>
         <div>
-          <a href="https://roboflow.com/" target="_blank" rel="noopener" aria-label="Roboflow">
+          <a href="https://roboflow.com/" target="_blank" rel="sponsored nofollow noopener" aria-label="Roboflow">
             <img src="/images/sponsors/roboflow.png" alt="Roboflow" />
             <br />
             Roboflow
           </a>
         </div>
         <div>
-          <a href="https://www.zezelife.com/" target="_blank" rel="noopener" aria-label="ZezeLife">
+          <a href="https://www.zezelife.com/" target="_blank" rel="sponsored nofollow noopener" aria-label="ZezeLife">
             <img src="/images/sponsors/zezelife.png" alt="ZezeLife" />
             <br />
             ZezeLife
@@ -127,56 +137,76 @@ export function Sponsors() {
 
       <div className="sponsors">
         <div>
-          <a href="https://www.xndoll.com" target="_blank" rel="noopener" aria-label="XNDOLL">
+          <a href="https://www.xndoll.com" target="_blank" rel="sponsored nofollow noopener" aria-label="XNDOLL">
             <img src="/images/sponsors/xndoll.png" alt="XNDOLL" />
             <br />
             XNDOLL
           </a>
         </div>
         <div>
-          <a href="https://www.pidoll.com" target="_blank" rel="noopener" aria-label="PIDOLL">
+          <a href="https://www.pidoll.com" target="_blank" rel="sponsored nofollow noopener" aria-label="PIDOLL">
             <img src="/images/sponsors/pidoll.png" alt="PIDOLL" />
             <br />
             PIDOLL
           </a>
         </div>
         <div>
-          <a href="https://www.palstoy.com" target="_blank" rel="noopener" aria-label="PalsToy">
+          <a href="https://www.palstoy.com" target="_blank" rel="sponsored nofollow noopener" aria-label="PalsToy">
             <img src="/images/sponsors/palstoy.png" alt="PalsToy" />
             <br />
             PalsToy
           </a>
         </div>
         <div>
-          <a href="https://www.bestblowjobmachines.com/" target="_blank" rel="noopener" aria-label="Mark Mitchell">
+          <a
+            href="https://www.bestblowjobmachines.com/"
+            target="_blank"
+            rel="sponsored nofollow noopener"
+            aria-label="Mark Mitchell"
+          >
             <img src="/images/sponsors/bestblowjobmachines.png" alt="Mark Mitchell" />
             <br />
             Mark Mitchell
           </a>
         </div>
         <div>
-          <a href="https://pleasuremenow.com/" target="_blank" rel="noopener" aria-label="Pleasure Me Now">
+          <a
+            href="https://pleasuremenow.com/"
+            target="_blank"
+            rel="sponsored nofollow noopener"
+            aria-label="Pleasure Me Now"
+          >
             <img src="/images/sponsors/pleasuremenow.png" alt="Pleasure Me Now" />
             <br />
             Pleasure Me Now
           </a>
         </div>
         <div>
-          <a href="https://www.sosexdoll.com/cheap-sex-doll" target="_blank" rel="noopener" aria-label="SoSexDoll">
+          <a
+            href="https://www.sosexdoll.com/cheap-sex-doll"
+            target="_blank"
+            rel="sponsored nofollow noopener"
+            aria-label="SoSexDoll"
+          >
             <img src="/images/sponsors/sosexdoll.png" alt="SoSexDoll" />
             <br />
             SoSexDoll
           </a>
         </div>
         <div>
-          <a href="https://www.hismith.com/en/" target="_blank" rel="noopener" aria-label="Hismith">
+          <a href="https://www.hismith.com/en/" target="_blank" rel="sponsored nofollow noopener" aria-label="Hismith">
             <img src="/images/sponsors/hismith.png" alt="Hismith" />
             <br />
             Hismith
           </a>
         </div>
         <div>
-          <a href="https://www.sexdollpartner.com/" target="_blank" rel="noopener" aria-label="SexDollPartner">
+          <a
+            href="https://www.sexdollpartner.com/"
+            target="_blank"
+            rel="sponsored nofollow noopener"
+            aria-label="SexDollPartner"
+          >
             <img src="/images/sponsors/sexdollpartner.jpg" alt="SexDollPartner" />
             <br />
             SexDollPartner
@@ -186,7 +216,7 @@ export function Sponsors() {
           <a
             href="https://www.xspacecup.com/"
             target="_blank"
-            rel="noopener"
+            rel="sponsored nofollow noopener"
             aria-label="XspaceCup - Top Male Masturbator Brand"
           >
             <img src="/images/sponsors/xspacecup.png" alt="XspaceCup - Top Male Masturbator Brand" />
@@ -195,21 +225,26 @@ export function Sponsors() {
           </a>
         </div>
         <div>
-          <a href="https://www.nakedoll.com/" target="_blank" rel="noopener" aria-label="NakeDoll">
+          <a href="https://www.nakedoll.com/" target="_blank" rel="sponsored nofollow noopener" aria-label="NakeDoll">
             <img src="/images/sponsors/nakedoll.png" alt="NakeDoll" />
             <br />
             NakeDoll
           </a>
         </div>
         <div>
-          <a href="https://vsdoll.net/" target="_blank" rel="noopener" aria-label="VSDoll">
+          <a href="https://vsdoll.net/" target="_blank" rel="sponsored nofollow noopener" aria-label="VSDoll">
             <img src="/images/sponsors/vsdoll.png" alt="VSDoll" />
             <br />
             VSDoll
           </a>
         </div>
         <div>
-          <a href="https://www.sextorso.com/" target="_blank" rel="noopener" aria-label="sexdoll torso">
+          <a
+            href="https://www.sextorso.com/"
+            target="_blank"
+            rel="sponsored nofollow noopener"
+            aria-label="sexdoll torso"
+          >
             <img src="/images/sponsors/sextorso.png" alt="sexdoll torso" />
             <br />
             sexdoll torso
@@ -219,7 +254,7 @@ export function Sponsors() {
           <a
             href="https://www.minisexdoll.com/anime-sexdoll/"
             target="_blank"
-            rel="noopener"
+            rel="sponsored nofollow noopener"
             aria-label="anime sexdoll"
           >
             <img src="/images/sponsors/minisexdoll.png" alt="anime sexdoll" />
@@ -228,21 +263,31 @@ export function Sponsors() {
           </a>
         </div>
         <div>
-          <a href="https://www.myminisexdoll.com/under-300/" target="_blank" rel="noopener" aria-label="cheap sexdoll">
+          <a
+            href="https://www.myminisexdoll.com/under-300/"
+            target="_blank"
+            rel="sponsored nofollow noopener"
+            aria-label="cheap sexdoll"
+          >
             <img src="/images/sponsors/myminisexdoll.png" alt="cheap sexdoll" />
             <br />
             cheap sexdoll
           </a>
         </div>
         <div>
-          <a href="https://www.hugedildo.com/" target="_blank" rel="noopener" aria-label="huge dildo">
+          <a
+            href="https://www.hugedildo.com/"
+            target="_blank"
+            rel="sponsored nofollow noopener"
+            aria-label="huge dildo"
+          >
             <img src="/images/sponsors/hugedildo.png" alt="huge dildo" />
             <br />
             huge dildo
           </a>
         </div>
         <div>
-          <a href="https://www.uusexdoll.com/" target="_blank" rel="noopener" aria-label="sexdoll">
+          <a href="https://www.uusexdoll.com/" target="_blank" rel="sponsored nofollow noopener" aria-label="sexdoll">
             <img src="/images/sponsors/uusexdoll.png" alt="sexdoll" />
             <br />
             sexdoll
@@ -252,7 +297,7 @@ export function Sponsors() {
           <a
             href="https://www.uusextoy.com/best-pocket-pussy/"
             target="_blank"
-            rel="noopener"
+            rel="sponsored nofollow noopener"
             aria-label="best pocket pussy"
           >
             <img src="/images/sponsors/uusextoy.png" alt="best pocket pussy" />
@@ -264,7 +309,7 @@ export function Sponsors() {
           <a
             href="https://www.lovedolltorso.com/female-torso-sex-doll/"
             target="_blank"
-            rel="noopener"
+            rel="sponsored nofollow noopener"
             aria-label="female torso sex doll"
           >
             <img src="/images/sponsors/lovedolltorso.png" alt="female torso sex doll" />
@@ -273,14 +318,24 @@ export function Sponsors() {
           </a>
         </div>
         <div>
-          <a href="https://www.mymasturbators.com/" target="_blank" rel="noopener" aria-label="male masturbator">
+          <a
+            href="https://www.mymasturbators.com/"
+            target="_blank"
+            rel="sponsored nofollow noopener"
+            aria-label="male masturbator"
+          >
             <img src="/images/sponsors/mymasturbators.png" alt="male masturbator" />
             <br />
             male masturbator
           </a>
         </div>
         <div>
-          <a href="https://www.buypenispump.com/" target="_blank" rel="noopener" aria-label="penis pump">
+          <a
+            href="https://www.buypenispump.com/"
+            target="_blank"
+            rel="sponsored nofollow noopener"
+            aria-label="penis pump"
+          >
             <img src="/images/sponsors/buypenispump.png" alt="penis pump" />
             <br />
             penis pump
@@ -290,7 +345,7 @@ export function Sponsors() {
           <a
             href="https://www.bestrealdoll.com/collections/us-warehouse"
             target="_blank"
-            rel="noopener"
+            rel="sponsored nofollow noopener"
             aria-label="BestRealDoll"
           >
             <img src="/images/sponsors/bestrealdoll.jpeg" alt="BestRealDoll" />
@@ -302,7 +357,7 @@ export function Sponsors() {
           <a
             href="https://www.sexdolltech.com/product-category/us-warehouse/"
             target="_blank"
-            rel="noopener"
+            rel="sponsored nofollow noopener"
             aria-label="SexDollTech"
           >
             <img src="/images/sponsors/sexdolltech.jpeg" alt="SexDollTech" />
@@ -311,35 +366,45 @@ export function Sponsors() {
           </a>
         </div>
         <div>
-          <a href="https://www.sexdollsoff.com/" target="_blank" rel="noopener" aria-label="SexDollsOff">
+          <a
+            href="https://www.sexdollsoff.com/"
+            target="_blank"
+            rel="sponsored nofollow noopener"
+            aria-label="SexDollsOff"
+          >
             <img src="/images/sponsors/sexdollsoff.png" alt="YourDoll" />
             <br />
             SexDollsOff
           </a>
         </div>
         <div>
-          <a href="https://realsexdoll.com/" target="_blank" rel="noopener" aria-label="RealSexDoll">
+          <a href="https://realsexdoll.com/" target="_blank" rel="sponsored nofollow noopener" aria-label="RealSexDoll">
             <img src="/images/sponsors/realsexdoll.png" alt="YourDoll" />
             <br />
             RealSexDoll
           </a>
         </div>
         <div>
-          <a href="https://www.yourdoll.com/" target="_blank" rel="noopener" aria-label="YourDoll">
+          <a href="https://www.yourdoll.com/" target="_blank" rel="sponsored nofollow noopener" aria-label="YourDoll">
             <img src="/images/sponsors/yourdoll.jpg" alt="YourDoll" />
             <br />
             YourDoll
           </a>
         </div>
         <div>
-          <a href="https://anniesdollhouse.com/" target="_blank" rel="noopener" aria-label="Annie's Dollhouse">
+          <a
+            href="https://anniesdollhouse.com/"
+            target="_blank"
+            rel="sponsored nofollow noopener"
+            aria-label="Annie's Dollhouse"
+          >
             <img src="/images/sponsors/annies-dollhouse.png" alt="Annie's Dollhouse" />
             <br />
             Annie's Dollhouse
           </a>
         </div>
         <div>
-          <a href="https://sextoycollective.com/" target="_blank" rel="noopener" aria-label="STC">
+          <a href="https://sextoycollective.com/" target="_blank" rel="sponsored nofollow noopener" aria-label="STC">
             <img src="/images/sponsors/sextoycollective.jpg" alt="STC" />
             <br />
             STC
@@ -349,7 +414,7 @@ export function Sponsors() {
           <a
             href="https://doctorclimax.com/"
             target="_blank"
-            rel="noopener"
+            rel="sponsored nofollow noopener"
             aria-label="DoctorClimax"
             title="DoctorClimax"
           >
@@ -359,7 +424,7 @@ export function Sponsors() {
           </a>
         </div>
         <div>
-          <a href="https://www.bsdoll.com/" target="_blank" rel="noopener" aria-label="BSDoll">
+          <a href="https://www.bsdoll.com/" target="_blank" rel="sponsored nofollow noopener" aria-label="BSDoll">
             <img src="/images/sponsors/bsdoll.jpg" alt="BSDoll" />
             <br />
             BSDoll


### PR DESCRIPTION
Fixes #251.

## Problem

Every paid sponsor placement and affiliate link carried only `rel="noopener"`. That's a security/performance hint — it carries **no** ranking signal, so all ~43 monetised outbound links were passing PageRank.

Per [Google's link spam policies](https://developers.google.com/search/docs/essentials/spam-policies#link-spam), "buying or selling links that pass ranking credit" is a link scheme, and qualifying those links is the linking site's responsibility. The exposure is sitewide (manual action / algorithmic demotion), not limited to the links themselves.

## Changes

| File | Links | New `rel` |
|---|---|---|
| `src/components/Sponsors.tsx` | 38 | `sponsored nofollow noopener` |
| `src/components/Prtnr.tsx` | 1 anchor (all 5 referral URLs route through it) | `sponsored nofollow noreferrer noopener` |
| `src/components/Partners.tsx` | 1 | `sponsored nofollow noreferrer noopener` |

`rel="sponsored"` is the correct value for both paid placements and affiliate links; `nofollow` is included alongside it for crawlers that don't understand `sponsored`.

`Partners.tsx` is currently commented out in `Nav`, so that change is purely so it's correct if it's ever re-enabled.

## Deliberately not changed

- **The two "Add your logo and link for $29 per month" anchors** point at our own `SPONSORS.md`. Internal link, not a paid one — they keep plain `rel="noopener"`. Nofollowing our own repo would just discard the link.
- **Editorial outbound links** — MDN (`DeclarativeTemplates.tsx:61`), animate.style (`Examples.tsx:131`), jsDelivr and the four framework-integration repos (`Installation.tsx`). None are paid; qualifying them would throw away legitimate signal.

`tiagostutz` **is** qualified — he's a paying sponsor receiving a logo and link, so it's a paid link regardless of the destination being GitHub.

## Verification

- `bun run lint` passes. (`oxfmt` reflowed `Sponsors.tsx` where the longer attribute pushed lines past the width limit — that's the bulk of the diff.)
- `bun run build` succeeds.
- Confirmed the attribute reaches the shipped bundle, which matters because the site is client-rendered and the `rel` only exists inside JS: `dist/assets/components-*.js` contains 38 occurrences of `sponsored nofollow noopener` and 1 of the `noreferrer` variant — matching the source exactly.

## Follow-up worth considering

Nothing stops the next sponsor from being added without the `rel`. A small `<SponsorLink>` component that hardcodes it would make that impossible; I left it out here to keep the diff reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
