### PR TITLE
feat: add custom 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+  <load ="partials/head.html" title="Page not found - SweetAlert2" canonical="/404.html" />
+  <body>
+    <div class="app-root"></div>
+    <script type="module" src="/src/404.tsx"></script>
+  </body>
+</html>

--- a/src/404.tsx
+++ b/src/404.tsx
@@ -1,0 +1,34 @@
+import { Nav } from './components'
+import { renderRecipe } from './utils'
+
+function NotFound() {
+  return (
+    <>
+      {/* recipeGallery renders the top nav with the search box; there is no gallery to go back to */}
+      <Nav recipeGallery showBackToRecipeGalleryLink={false} />
+
+      <h1>Page not found</h1>
+
+      <p className="center">
+        That page doesn't exist. It may have been renamed, or the link that brought you here may be out of date.
+      </p>
+
+      <ul className="recipes-list">
+        <li>
+          <a href="/">SweetAlert2 documentation</a>
+        </li>
+        <li>
+          <a href="/#examples">Examples</a>
+        </li>
+        <li>
+          <a href="/#configuration">Configuration Params</a>
+        </li>
+        <li>
+          <a href="/recipe-gallery/">Recipe Gallery</a>
+        </li>
+      </ul>
+    </>
+  )
+}
+
+renderRecipe(<NotFound />)

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,6 +11,7 @@ export default defineConfig({
     rolldownOptions: {
       input: {
         'main': 'index.html',
+        '404': '404.html',
         'recipe-gallery': 'recipe-gallery/index.html',
         'queue-with-progress-steps': 'recipe-gallery/queue-with-progress-steps.html',
         'bootstrap-custom-loader': 'recipe-gallery/bootstrap-custom-loader.html',


### PR DESCRIPTION
Closes #257.

GitHub Pages served its generic 404 for any unmatched path — no navigation, no search, and no internal links for crawlers to follow onward. Since recipe URLs are `.html`-suffixed, extension-less or misremembered variants (`/recipe-gallery/colored-toasts`) all landed there.

## Changes

- **`404.html`** + **`src/404.tsx`** — site chrome, the DocSearch box, and links to the docs, Examples, Configuration Params, and the Recipe Gallery
- **`vite.config.js`** — new `404` build entry

Reuses `<Nav recipeGallery showBackToRecipeGalleryLink={false} />` — the same call `recipe-gallery/index.tsx` already makes, which renders the top nav with the search box and no back-link. That means no new CSS, and the runtime path is already proven in production.

## Decisions

**A real 404, not a redirect to `/`.** Redirecting would convert hard 404s into soft 404s, which Search Console flags as errors.

**Kept out of `sitemap.xml`** (verified below). The HTTP 404 status GitHub Pages returns is the authoritative signal that keeps it out of the index — which is also why there's no `noindex` meta tag: the head partial is injected wholesale, so a page-specific meta tag can't be appended to it, and the status code makes one unnecessary.

**Title carries the brand** (`Page not found - SweetAlert2`) so the tab is identifiable. Recipe titles don't yet; #254 normalises that across all pages.

## Verification

- `dist/404.html` builds with correct `<title>`, a canonical, and zero unreplaced `{=$...}` placeholders.
- Served `dist/` and confirmed `/404.html` → HTTP 200, its JS chunk → HTTP 200, and the single module it imports (the shared `components-*.js`, same chunk the homepage uses) → HTTP 200. Module graph is complete, so the page won't render blank.
- `sitemap.xml` still lists exactly 22 URLs and contains no `404` entry.
- `bun run lint` and `bun run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
