### PR TITLE
perf: lazy-load below-the-fold images

### DIFF
--- a/recipe-gallery/sweetalert2-laravel.tsx
+++ b/recipe-gallery/sweetalert2-laravel.tsx
@@ -97,6 +97,8 @@ Swal::toastQuestion([
           src="https://github.com/sweetalert2/sweetalert2-laravel/raw/main/sweetalert2-laravel.png"
           alt="SweetAlert2 Laravel integration demo screenshot"
           style={{ maxWidth: 840 }}
+          loading="lazy"
+          decoding="async"
         />
       </p>
     </>

--- a/src/components/Installation.tsx
+++ b/src/components/Installation.tsx
@@ -79,7 +79,7 @@ import 'sweetalert2/src/sweetalert2.scss'`}
             >
               React
               <br />
-              <img src="/images/react.svg" width="125" alt="" />
+              <img src="/images/react.svg" width="125" alt="" loading="lazy" decoding="async" />
             </a>
           </div>
           <div>
@@ -91,7 +91,7 @@ import 'sweetalert2/src/sweetalert2.scss'`}
             >
               Vue
               <br />
-              <img src="/images/vue.png" width="125" alt="" />
+              <img src="/images/vue.png" width="125" alt="" loading="lazy" decoding="async" />
             </a>
           </div>
           <div>
@@ -103,7 +103,7 @@ import 'sweetalert2/src/sweetalert2.scss'`}
             >
               Angular
               <br />
-              <img src="/images/angular.svg" width="125" alt="" />
+              <img src="/images/angular.svg" width="125" alt="" loading="lazy" decoding="async" />
             </a>
           </div>
           <div>
@@ -115,7 +115,7 @@ import 'sweetalert2/src/sweetalert2.scss'`}
             >
               Laravel
               <br />
-              <img src="/images/laravel.svg" width="125" alt="" />
+              <img src="/images/laravel.svg" width="125" alt="" loading="lazy" decoding="async" />
             </a>
           </div>
         </div>

--- a/src/components/Sponsors.tsx
+++ b/src/components/Sponsors.tsx
@@ -16,7 +16,7 @@ export function Sponsors() {
             rel="noopener"
             aria-label="Add your logo and link here"
           >
-            <img src="/images/plus.png" alt="" />
+            <img src="/images/plus.png" alt="" loading="lazy" decoding="async" />
             <br />
             Add your logo and link
             <br />
@@ -28,21 +28,21 @@ export function Sponsors() {
       <div className="sponsors">
         <div>
           <a href="https://www.blueplenum.com/" target="_blank" rel="noopener" aria-label="BluePlenum">
-            <img src="/images/sponsors/blueplenum.jpg" alt="BluePlenum" />
+            <img src="/images/sponsors/blueplenum.jpg" alt="BluePlenum" loading="lazy" decoding="async" />
             <br />
             BluePlenum
           </a>
         </div>
         <div>
           <a href="https://kryptot.fi/" target="_blank" rel="noopener" aria-label="Kryptot">
-            <img src="/images/sponsors/kryptot.png" alt="Kryptot" />
+            <img src="/images/sponsors/kryptot.png" alt="Kryptot" loading="lazy" decoding="async" />
             <br />
             Kryptot
           </a>
         </div>
         <div>
           <a href="https://www.inksonic.com/" target="_blank" rel="noopener" aria-label="InkSonic">
-            <img src="/images/sponsors/inksonic.png" alt="InkSonic" />
+            <img src="/images/sponsors/inksonic.png" alt="InkSonic" loading="lazy" decoding="async" />
             <br />
             InkSonic
           </a>
@@ -54,7 +54,12 @@ export function Sponsors() {
             rel="noopener"
             aria-label="Your Occupational Healthcare Hub"
           >
-            <img src="/images/sponsors/bluehive.png" alt="Your Occupational Healthcare Hub" />
+            <img
+              src="/images/sponsors/bluehive.png"
+              alt="Your Occupational Healthcare Hub"
+              loading="lazy"
+              decoding="async"
+            />
             <br />
             Your Occupational Healthcare Hub
           </a>
@@ -66,35 +71,40 @@ export function Sponsors() {
             rel="noopener"
             aria-label="Buy Youtube Views"
           >
-            <img src="/images/sponsors/ssmarket.png" alt="Buy Youtube Views" />
+            <img src="/images/sponsors/ssmarket.png" alt="Buy Youtube Views" loading="lazy" decoding="async" />
             <br />
             Buy Youtube Views
           </a>
         </div>
         <div>
           <a href="https://github.com/tiagostutz" target="_blank" rel="noopener" aria-label="Tiago de Oliveira Stutz">
-            <img src="https://avatars0.githubusercontent.com/u/3986989?s=200&v=4" alt="Tiago de Oliveira Stutz" />
+            <img
+              src="https://avatars0.githubusercontent.com/u/3986989?s=200&v=4"
+              alt="Tiago de Oliveira Stutz"
+              loading="lazy"
+              decoding="async"
+            />
             <br />
             Tiago de Oliveira Stutz
           </a>
         </div>
         <div>
           <a href="https://istar.tips/" target="_blank" rel="noopener" aria-label="iStarTips">
-            <img src="/images/sponsors/istartips.png" alt="iStarTips" />
+            <img src="/images/sponsors/istartips.png" alt="iStarTips" loading="lazy" decoding="async" />
             <br />
             iStarTips
           </a>
         </div>
         <div>
           <a href="https://roboflow.com/" target="_blank" rel="noopener" aria-label="Roboflow">
-            <img src="/images/sponsors/roboflow.png" alt="Roboflow" />
+            <img src="/images/sponsors/roboflow.png" alt="Roboflow" loading="lazy" decoding="async" />
             <br />
             Roboflow
           </a>
         </div>
         <div>
           <a href="https://www.zezelife.com/" target="_blank" rel="noopener" aria-label="ZezeLife">
-            <img src="/images/sponsors/zezelife.png" alt="ZezeLife" />
+            <img src="/images/sponsors/zezelife.png" alt="ZezeLife" loading="lazy" decoding="async" />
             <br />
             ZezeLife
           </a>
@@ -116,7 +126,7 @@ export function Sponsors() {
             rel="noopener"
             aria-label="Add your logo and link here"
           >
-            <img src="/images/plus.png" alt="" />
+            <img src="/images/plus.png" alt="" loading="lazy" decoding="async" />
             <br />
             Add your logo and link
             <br />
@@ -128,56 +138,56 @@ export function Sponsors() {
       <div className="sponsors">
         <div>
           <a href="https://www.xndoll.com" target="_blank" rel="noopener" aria-label="XNDOLL">
-            <img src="/images/sponsors/xndoll.png" alt="XNDOLL" />
+            <img src="/images/sponsors/xndoll.png" alt="XNDOLL" loading="lazy" decoding="async" />
             <br />
             XNDOLL
           </a>
         </div>
         <div>
           <a href="https://www.pidoll.com" target="_blank" rel="noopener" aria-label="PIDOLL">
-            <img src="/images/sponsors/pidoll.png" alt="PIDOLL" />
+            <img src="/images/sponsors/pidoll.png" alt="PIDOLL" loading="lazy" decoding="async" />
             <br />
             PIDOLL
           </a>
         </div>
         <div>
           <a href="https://www.palstoy.com" target="_blank" rel="noopener" aria-label="PalsToy">
-            <img src="/images/sponsors/palstoy.png" alt="PalsToy" />
+            <img src="/images/sponsors/palstoy.png" alt="PalsToy" loading="lazy" decoding="async" />
             <br />
             PalsToy
           </a>
         </div>
         <div>
           <a href="https://www.bestblowjobmachines.com/" target="_blank" rel="noopener" aria-label="Mark Mitchell">
-            <img src="/images/sponsors/bestblowjobmachines.png" alt="Mark Mitchell" />
+            <img src="/images/sponsors/bestblowjobmachines.png" alt="Mark Mitchell" loading="lazy" decoding="async" />
             <br />
             Mark Mitchell
           </a>
         </div>
         <div>
           <a href="https://pleasuremenow.com/" target="_blank" rel="noopener" aria-label="Pleasure Me Now">
-            <img src="/images/sponsors/pleasuremenow.png" alt="Pleasure Me Now" />
+            <img src="/images/sponsors/pleasuremenow.png" alt="Pleasure Me Now" loading="lazy" decoding="async" />
             <br />
             Pleasure Me Now
           </a>
         </div>
         <div>
           <a href="https://www.sosexdoll.com/cheap-sex-doll" target="_blank" rel="noopener" aria-label="SoSexDoll">
-            <img src="/images/sponsors/sosexdoll.png" alt="SoSexDoll" />
+            <img src="/images/sponsors/sosexdoll.png" alt="SoSexDoll" loading="lazy" decoding="async" />
             <br />
             SoSexDoll
           </a>
         </div>
         <div>
           <a href="https://www.hismith.com/en/" target="_blank" rel="noopener" aria-label="Hismith">
-            <img src="/images/sponsors/hismith.png" alt="Hismith" />
+            <img src="/images/sponsors/hismith.png" alt="Hismith" loading="lazy" decoding="async" />
             <br />
             Hismith
           </a>
         </div>
         <div>
           <a href="https://www.sexdollpartner.com/" target="_blank" rel="noopener" aria-label="SexDollPartner">
-            <img src="/images/sponsors/sexdollpartner.jpg" alt="SexDollPartner" />
+            <img src="/images/sponsors/sexdollpartner.jpg" alt="SexDollPartner" loading="lazy" decoding="async" />
             <br />
             SexDollPartner
           </a>
@@ -189,28 +199,33 @@ export function Sponsors() {
             rel="noopener"
             aria-label="XspaceCup - Top Male Masturbator Brand"
           >
-            <img src="/images/sponsors/xspacecup.png" alt="XspaceCup - Top Male Masturbator Brand" />
+            <img
+              src="/images/sponsors/xspacecup.png"
+              alt="XspaceCup - Top Male Masturbator Brand"
+              loading="lazy"
+              decoding="async"
+            />
             <br />
             XspaceCup - Top Male Masturbator Brand
           </a>
         </div>
         <div>
           <a href="https://www.nakedoll.com/" target="_blank" rel="noopener" aria-label="NakeDoll">
-            <img src="/images/sponsors/nakedoll.png" alt="NakeDoll" />
+            <img src="/images/sponsors/nakedoll.png" alt="NakeDoll" loading="lazy" decoding="async" />
             <br />
             NakeDoll
           </a>
         </div>
         <div>
           <a href="https://vsdoll.net/" target="_blank" rel="noopener" aria-label="VSDoll">
-            <img src="/images/sponsors/vsdoll.png" alt="VSDoll" />
+            <img src="/images/sponsors/vsdoll.png" alt="VSDoll" loading="lazy" decoding="async" />
             <br />
             VSDoll
           </a>
         </div>
         <div>
           <a href="https://www.sextorso.com/" target="_blank" rel="noopener" aria-label="sexdoll torso">
-            <img src="/images/sponsors/sextorso.png" alt="sexdoll torso" />
+            <img src="/images/sponsors/sextorso.png" alt="sexdoll torso" loading="lazy" decoding="async" />
             <br />
             sexdoll torso
           </a>
@@ -222,28 +237,28 @@ export function Sponsors() {
             rel="noopener"
             aria-label="anime sexdoll"
           >
-            <img src="/images/sponsors/minisexdoll.png" alt="anime sexdoll" />
+            <img src="/images/sponsors/minisexdoll.png" alt="anime sexdoll" loading="lazy" decoding="async" />
             <br />
             anime sexdoll
           </a>
         </div>
         <div>
           <a href="https://www.myminisexdoll.com/under-300/" target="_blank" rel="noopener" aria-label="cheap sexdoll">
-            <img src="/images/sponsors/myminisexdoll.png" alt="cheap sexdoll" />
+            <img src="/images/sponsors/myminisexdoll.png" alt="cheap sexdoll" loading="lazy" decoding="async" />
             <br />
             cheap sexdoll
           </a>
         </div>
         <div>
           <a href="https://www.hugedildo.com/" target="_blank" rel="noopener" aria-label="huge dildo">
-            <img src="/images/sponsors/hugedildo.png" alt="huge dildo" />
+            <img src="/images/sponsors/hugedildo.png" alt="huge dildo" loading="lazy" decoding="async" />
             <br />
             huge dildo
           </a>
         </div>
         <div>
           <a href="https://www.uusexdoll.com/" target="_blank" rel="noopener" aria-label="sexdoll">
-            <img src="/images/sponsors/uusexdoll.png" alt="sexdoll" />
+            <img src="/images/sponsors/uusexdoll.png" alt="sexdoll" loading="lazy" decoding="async" />
             <br />
             sexdoll
           </a>
@@ -255,7 +270,7 @@ export function Sponsors() {
             rel="noopener"
             aria-label="best pocket pussy"
           >
-            <img src="/images/sponsors/uusextoy.png" alt="best pocket pussy" />
+            <img src="/images/sponsors/uusextoy.png" alt="best pocket pussy" loading="lazy" decoding="async" />
             <br />
             best pocket pussy
           </a>
@@ -267,21 +282,21 @@ export function Sponsors() {
             rel="noopener"
             aria-label="female torso sex doll"
           >
-            <img src="/images/sponsors/lovedolltorso.png" alt="female torso sex doll" />
+            <img src="/images/sponsors/lovedolltorso.png" alt="female torso sex doll" loading="lazy" decoding="async" />
             <br />
             female torso sex doll
           </a>
         </div>
         <div>
           <a href="https://www.mymasturbators.com/" target="_blank" rel="noopener" aria-label="male masturbator">
-            <img src="/images/sponsors/mymasturbators.png" alt="male masturbator" />
+            <img src="/images/sponsors/mymasturbators.png" alt="male masturbator" loading="lazy" decoding="async" />
             <br />
             male masturbator
           </a>
         </div>
         <div>
           <a href="https://www.buypenispump.com/" target="_blank" rel="noopener" aria-label="penis pump">
-            <img src="/images/sponsors/buypenispump.png" alt="penis pump" />
+            <img src="/images/sponsors/buypenispump.png" alt="penis pump" loading="lazy" decoding="async" />
             <br />
             penis pump
           </a>
@@ -293,7 +308,7 @@ export function Sponsors() {
             rel="noopener"
             aria-label="BestRealDoll"
           >
-            <img src="/images/sponsors/bestrealdoll.jpeg" alt="BestRealDoll" />
+            <img src="/images/sponsors/bestrealdoll.jpeg" alt="BestRealDoll" loading="lazy" decoding="async" />
             <br />
             BestRealDoll
           </a>
@@ -305,42 +320,42 @@ export function Sponsors() {
             rel="noopener"
             aria-label="SexDollTech"
           >
-            <img src="/images/sponsors/sexdolltech.jpeg" alt="SexDollTech" />
+            <img src="/images/sponsors/sexdolltech.jpeg" alt="SexDollTech" loading="lazy" decoding="async" />
             <br />
             SexDollTech
           </a>
         </div>
         <div>
           <a href="https://www.sexdollsoff.com/" target="_blank" rel="noopener" aria-label="SexDollsOff">
-            <img src="/images/sponsors/sexdollsoff.png" alt="YourDoll" />
+            <img src="/images/sponsors/sexdollsoff.png" alt="YourDoll" loading="lazy" decoding="async" />
             <br />
             SexDollsOff
           </a>
         </div>
         <div>
           <a href="https://realsexdoll.com/" target="_blank" rel="noopener" aria-label="RealSexDoll">
-            <img src="/images/sponsors/realsexdoll.png" alt="YourDoll" />
+            <img src="/images/sponsors/realsexdoll.png" alt="YourDoll" loading="lazy" decoding="async" />
             <br />
             RealSexDoll
           </a>
         </div>
         <div>
           <a href="https://www.yourdoll.com/" target="_blank" rel="noopener" aria-label="YourDoll">
-            <img src="/images/sponsors/yourdoll.jpg" alt="YourDoll" />
+            <img src="/images/sponsors/yourdoll.jpg" alt="YourDoll" loading="lazy" decoding="async" />
             <br />
             YourDoll
           </a>
         </div>
         <div>
           <a href="https://anniesdollhouse.com/" target="_blank" rel="noopener" aria-label="Annie's Dollhouse">
-            <img src="/images/sponsors/annies-dollhouse.png" alt="Annie's Dollhouse" />
+            <img src="/images/sponsors/annies-dollhouse.png" alt="Annie's Dollhouse" loading="lazy" decoding="async" />
             <br />
             Annie's Dollhouse
           </a>
         </div>
         <div>
           <a href="https://sextoycollective.com/" target="_blank" rel="noopener" aria-label="STC">
-            <img src="/images/sponsors/sextoycollective.jpg" alt="STC" />
+            <img src="/images/sponsors/sextoycollective.jpg" alt="STC" loading="lazy" decoding="async" />
             <br />
             STC
           </a>
@@ -353,14 +368,14 @@ export function Sponsors() {
             aria-label="DoctorClimax"
             title="DoctorClimax"
           >
-            <img src="/images/sponsors/doctorclimax.png" alt="DoctorClimax" />
+            <img src="/images/sponsors/doctorclimax.png" alt="DoctorClimax" loading="lazy" decoding="async" />
             <br />
             DoctorClimax
           </a>
         </div>
         <div>
           <a href="https://www.bsdoll.com/" target="_blank" rel="noopener" aria-label="BSDoll">
-            <img src="/images/sponsors/bsdoll.jpg" alt="BSDoll" />
+            <img src="/images/sponsors/bsdoll.jpg" alt="BSDoll" loading="lazy" decoding="async" />
             <br />
             BSDoll
           </a>

--- a/src/components/Themes.tsx
+++ b/src/components/Themes.tsx
@@ -18,7 +18,14 @@ export function Themes() {
             <tr>
               <td>
                 <h4>dark</h4>
-                <img src="/images/themes-dark.png" alt="SweetAlert2 Dark Theme" width={300} style={{ marginTop: 10 }} />
+                <img
+                  src="/images/themes-dark.png"
+                  alt="SweetAlert2 Dark Theme"
+                  width={300}
+                  style={{ marginTop: 10 }}
+                  loading="lazy"
+                  decoding="async"
+                />
               </td>
               <td>
                 Dark theme is included by default. To use it, just set the <strong>theme</strong> parameter to{' '}
@@ -43,8 +50,18 @@ export function Themes() {
               <td>
                 <h4>auto</h4>
                 <div className="theme-comparison">
-                  <img src="/images/themes-auto-light.png" alt="SweetAlert2 Auto Theme Light" />
-                  <img src="/images/themes-auto-dark.png" alt="SweetAlert2 Auto Theme Dark" />
+                  <img
+                    src="/images/themes-auto-light.png"
+                    alt="SweetAlert2 Auto Theme Light"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                  <img
+                    src="/images/themes-auto-dark.png"
+                    alt="SweetAlert2 Auto Theme Dark"
+                    loading="lazy"
+                    decoding="async"
+                  />
                 </div>
               </td>
               <td>
@@ -71,8 +88,18 @@ export function Themes() {
               <td>
                 <h4>bootstrap-5</h4>
                 <div className="theme-comparison">
-                  <img src="/images/themes-bootstrap-5-light.png" alt="SweetAlert2 Bootstrap 5 Theme Light" />
-                  <img src="/images/themes-bootstrap-5-dark.png" alt="SweetAlert2 Bootstrap 5 Theme Dark" />
+                  <img
+                    src="/images/themes-bootstrap-5-light.png"
+                    alt="SweetAlert2 Bootstrap 5 Theme Light"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                  <img
+                    src="/images/themes-bootstrap-5-dark.png"
+                    alt="SweetAlert2 Bootstrap 5 Theme Dark"
+                    loading="lazy"
+                    decoding="async"
+                  />
                 </div>
               </td>
               <td>
@@ -103,8 +130,18 @@ Swal.fire({
               <td>
                 <h4>bootstrap-4</h4>
                 <div className="theme-comparison">
-                  <img src="/images/themes-bootstrap-4-light.png" alt="SweetAlert2 Bootstrap 4 Theme Light" />
-                  <img src="/images/themes-bootstrap-4-dark.png" alt="SweetAlert2 Bootstrap 4 Theme Dark" />
+                  <img
+                    src="/images/themes-bootstrap-4-light.png"
+                    alt="SweetAlert2 Bootstrap 4 Theme Light"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                  <img
+                    src="/images/themes-bootstrap-4-dark.png"
+                    alt="SweetAlert2 Bootstrap 4 Theme Dark"
+                    loading="lazy"
+                    decoding="async"
+                  />
                 </div>
               </td>
               <td>
@@ -135,8 +172,18 @@ Swal.fire({
               <td>
                 <h4>material-ui</h4>
                 <div className="theme-comparison">
-                  <img src="/images/themes-material-ui-light.png" alt="SweetAlert2 Material UI Theme Light" />
-                  <img src="/images/themes-material-ui-dark.png" alt="SweetAlert2 Material UI Theme Dark" />
+                  <img
+                    src="/images/themes-material-ui-light.png"
+                    alt="SweetAlert2 Material UI Theme Light"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                  <img
+                    src="/images/themes-material-ui-dark.png"
+                    alt="SweetAlert2 Material UI Theme Dark"
+                    loading="lazy"
+                    decoding="async"
+                  />
                 </div>
               </td>
               <td>
@@ -167,8 +214,18 @@ Swal.fire({
               <td>
                 <h4>bulma</h4>
                 <div className="theme-comparison">
-                  <img src="/images/themes-bulma-light.png" alt="SweetAlert2 Bulma Theme Light" />
-                  <img src="/images/themes-bulma-dark.png" alt="SweetAlert2 Bulma Theme Dark" />
+                  <img
+                    src="/images/themes-bulma-light.png"
+                    alt="SweetAlert2 Bulma Theme Light"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                  <img
+                    src="/images/themes-bulma-dark.png"
+                    alt="SweetAlert2 Bulma Theme Dark"
+                    loading="lazy"
+                    decoding="async"
+                  />
                 </div>
               </td>
               <td>


### PR DESCRIPTION
Part of #258 — the lazy-loading item. See [my corrections on the issue](https://github.com/sweetalert2/sweetalert2.github.io/issues/258#issuecomment-5190124344): two of its four findings didn't survive re-checking, and this PR fixes the one that did.

## Problem

No image on the site had `loading="lazy"`. The homepage eager-loaded **40 sponsor logos** and **11 theme screenshots** far below the fold, all competing for bandwidth with the LCP element.

## Changes

56 of 59 images get `loading="lazy" decoding="async"`:

| File | Images |
|---|---|
| `src/components/Sponsors.tsx` | 40 |
| `src/components/Themes.tsx` | 11 |
| `src/components/Installation.tsx` | 4 |
| `recipe-gallery/sweetalert2-laravel.tsx` | 1 |

**The 3 above-the-fold logos stay eager on purpose** — the two in `Header.tsx` (logo track + `#logo-text`) and the one in `Showcase.tsx`. Lazy-loading the LCP element delays LCP, which would have made the metric worse rather than better.

## Verification

Checked the built output, not just the source:

- **56** `loading: "lazy"` props across all chunks, matching the source count exactly (55 in the shared `components-*.js` = Sponsors 40 + Themes 11 + Installation 4; the 56th in `sweetalert2-laravel-*.js`, which is its own build entry).
- Same count for `decoding: "async"`.
- Confirmed programmatically that no `loading: "lazy"` appears near `SweetAlert2.png` or `logo-donut-track.svg` in the bundle — the above-the-fold logos really are still eager.
- `bun run lint` and `bun run build` pass. `oxfmt` reflowed the affected `<img>` tags onto multiple lines, which is most of the diff's line count.

## Not in this PR

`#258` stays open for WebP/AVIF conversion and the three narrow CLS cases (the `.theme-comparison` grid overlays, `#logo-text`, and the laravel screenshot) — each needs individual layout reasoning rather than a mechanical attribute sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
