### PR TITLE
feat: add JSON-LD structured data

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,25 @@
   <body>
     <div class="app-root"></div>
     <div id="rtl-container" dir="rtl"></div>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareSourceCode",
+        "name": "SweetAlert2",
+        "description": "A beautiful, responsive, customizable, accessible (WAI-ARIA) replacement for JavaScript's popup boxes",
+        "url": "https://sweetalert2.github.io/",
+        "codeRepository": "https://github.com/sweetalert2/sweetalert2",
+        "programmingLanguage": "JavaScript",
+        "runtimePlatform": "JavaScript",
+        "license": "https://opensource.org/licenses/MIT",
+        "author": {
+          "@type": "Organization",
+          "name": "SweetAlert2",
+          "url": "https://github.com/sweetalert2",
+          "logo": "https://sweetalert2.github.io/images/SweetAlert2.png"
+        }
+      }
+    </script>
     <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>

--- a/tools/generate-recipe-html.mjs
+++ b/tools/generate-recipe-html.mjs
@@ -35,17 +35,60 @@ const recipes = [
 ]
 
 /**
+ * Serialise a JSON-LD object for embedding in a <script> tag.
+ * `<` is escaped so a value can never terminate the script element early.
+ * @param {object} data
+ * @returns {string}
+ */
+function jsonLd(data) {
+  return JSON.stringify(data, null, 2).replace(/</g, '\\u003c')
+}
+
+/**
+ * BreadcrumbList for a recipe page: SweetAlert2 > Recipe Gallery > <recipe>.
+ * The gallery index itself stops at the second level. The final crumb omits
+ * `item`, since it is the current page.
+ * @param {{name: string, title: string}} recipe
+ * @returns {string}
+ */
+function breadcrumbJsonLd(recipe) {
+  const crumbs = [{ '@type': 'ListItem', 'position': 1, 'name': 'SweetAlert2', 'item': `${SITE_URL}/` }]
+
+  if (recipe.name === 'index') {
+    crumbs.push({ '@type': 'ListItem', 'position': 2, 'name': 'Recipe Gallery' })
+  } else {
+    crumbs.push({
+      '@type': 'ListItem',
+      'position': 2,
+      'name': 'Recipe Gallery',
+      'item': `${SITE_URL}/recipe-gallery/`,
+    })
+    crumbs.push({ '@type': 'ListItem', 'position': 3, 'name': recipe.title })
+  }
+
+  return jsonLd({
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    'itemListElement': crumbs,
+  })
+}
+
+/**
  * @param {string} title
  * @param {string} scriptSrc
  * @param {string} canonical Site-root-relative canonical path
+ * @param {string} structuredData JSON-LD payload for the page
  * @returns {string}
  */
-function generateHtml(title, scriptSrc, canonical) {
+function generateHtml(title, scriptSrc, canonical, structuredData) {
   return `<!DOCTYPE html>
 <html lang="en">
   <load ="partials/head.html" title="${title}" canonical="${canonical}" />
   <body>
     <div class="app-root"></div>
+    <script type="application/ld+json">
+${structuredData}
+    </script>
     <script type="module" src="${scriptSrc}"></script>
   </body>
 </html>
@@ -69,7 +112,7 @@ mkdirSync(recipeDir, { recursive: true })
 
 for (const recipe of recipes) {
   const htmlPath = resolve(recipeDir, `${recipe.name}.html`)
-  const html = generateHtml(recipe.title, `./${recipe.name}.tsx`, canonicalPath(recipe.name))
+  const html = generateHtml(recipe.title, `./${recipe.name}.tsx`, canonicalPath(recipe.name), breadcrumbJsonLd(recipe))
   writeFileSync(htmlPath, html, 'utf-8')
   console.log(`Generated: ${recipe.name}.html`)
 }


### PR DESCRIPTION
Part of #255. See [my correction on the issue](https://github.com/sweetalert2/sweetalert2.github.io/issues/255#issuecomment-5190170131) — one of its six items is dead, and only one of the rest produces a Google rich result.

## Changes

**`BreadcrumbList` on all 21 recipe pages** (`tools/generate-recipe-html.mjs`) — generated from the same `recipes` array that already drives the HTML and `sitemap.xml`, so it can't drift. This is the item that earns something: Google renders a breadcrumb trail in place of the raw URL in search results.

```
SweetAlert2 > Recipe Gallery > Colored Toasts
```

The gallery index stops at two levels, and the final crumb omits `item` since it's the current page.

**`SoftwareSourceCode` + nested `Organization` on the homepage** (`index.html`) — name, description, repo, language, MIT license, author. No rich result, but cheap, valid, and genuinely useful to non-Google consumers (LLM crawlers and anything else reading schema.org).

Both are **static markup in the `<body>`**, so they're present without JS — which matters given the site is otherwise CSR (#253). JSON-LD is valid in `body` as well as `head`.

## Deliberately left out

- **`WebSite` + `SearchAction`** — Google retired the sitelinks search box in November 2024; the markup now does nothing.
- **`TechArticle`** — would duplicate the `<title>`/description already present, and `datePublished`/`dateModified` have no honest source (same reasoning as no `<lastmod>` in #252).
- **`SoftwareApplication`** — its rich result wants `aggregateRating`/`offers` and targets installable apps. Inventing ratings would be fabrication.

## Implementation note

JSON is built with `JSON.stringify` rather than string concatenation, and `<` is escaped to `<` so no recipe title can terminate the `<script>` element early. Verified with the awkward title in the set: `input[number] + input[range]` round-trips intact.

## Verification

- **22/22 pages** carry a JSON-LD block, and **every block parses as valid JSON** (re-validated after `oxfmt` reflowed the generator).
- Breadcrumb `position` values are sequential on every page, and the last crumb has no `item` on any page — both checked programmatically, not by eye.
- The 404 page correctly has none.
- `sitemap.xml` still lists exactly 22 URLs — unaffected.
- `bun run lint` and `bun run build` pass.

Worth running the two live validators once this deploys, since neither can see a local build: [Rich Results Test](https://search.google.com/test/rich-results) and [validator.schema.org](https://validator.schema.org/).

## Remaining in #255

Google prefers breadcrumb markup to match visible on-page navigation. Recipe pages have a "← Back to Recipe Gallery" link, which is a reasonable equivalent but not a real trail — adding a visible breadcrumb would strengthen it, and overlaps the "no breadcrumbs" point in #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
