### PR TITLE
fix: correct Open Graph and Twitter card meta tags

### DIFF
--- a/partials/head.html
+++ b/partials/head.html
@@ -5,21 +5,27 @@
 
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="icon" type="image/x-icon" href="/images/favicon.png" />
+  <link rel="icon" type="image/png" href="/images/favicon.png" />
+  <link rel="apple-touch-icon" href="/images/favicon.png" />
 
   <!-- Open Graph / Facebook -->
-  <meta property="og:title" content="SweetAlert2" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="SweetAlert2" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:title" content="{=$title}" />
   <meta property="og:description" content="{=$title}" />
-  <meta property="og:image" content="http://sweetalert2.github.io/images/sweetalert2-social.png" />
-  <meta property="og:url" content="https://sweetalert2.github.io/" />
+  <meta property="og:url" content="https://sweetalert2.github.io{=$canonical}" />
+  <meta property="og:image" content="https://sweetalert2.github.io/images/sweetalert2-social.png" />
+  <meta property="og:image:width" content="1280" />
+  <meta property="og:image:height" content="640" />
+  <meta property="og:image:alt" content="SweetAlert2 logo" />
 
   <!-- Twitter -->
-  <meta name="twitter:title" content="SweetAlert2" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="{=$title}" />
   <meta name="twitter:description" content="{=$title}" />
   <meta name="twitter:image" content="https://sweetalert2.github.io/images/sweetalert2-social.png" />
-  <meta name="twitter:card" content="summary_large_image" />
-
-  <link rel="icon" href="/images/favicon.png" />
+  <meta name="twitter:image:alt" content="SweetAlert2 logo" />
 
   <!-- https://goo.gl/qRE0vM -->
   <meta name="theme-color" content="#f2f4f6" />


### PR DESCRIPTION
Part of #254 — everything in it that's mechanical. All findings re-verified against the current `partials/head.html` before implementing.

## Fixed

| Problem | Before | After |
|---|---|---|
| `og:url` hardcoded to homepage — all 21 recipe pages claimed to be `/` when shared | `https://sweetalert2.github.io/` | uses the `canonical` param from #262 |
| `og:title` / `twitter:title` identical on every page | `SweetAlert2` | `{=$title}` |
| `og:image` insecure — while `twitter:image` two lines below was already `https` | `http://` | `https://` |
| `<link rel="icon">` declared twice, first with `type="image/x-icon"` for a PNG | 2 links, wrong MIME | 1 link, `image/png` |

**Added:** `og:type`, `og:site_name`, `og:locale`, `og:image:width` / `og:image:height`, `og:image:alt`, `twitter:image:alt`, and `apple-touch-icon`.

Dimensions were measured, not guessed: `sweetalert2-social.png` is **1280×640** (correct 2:1 for `summary_large_image`), and `favicon.png` is **160×160**, large enough to serve as the apple-touch-icon.

## Left out

**`twitter:site`** — the repo has no Twitter/X handle anywhere. I'm not inventing one.

**`meta description`** still duplicates `<title>`, so recipe pages get 1–4 word descriptions. That's the one part of #254 that isn't mechanical: it needs a real sentence per recipe, which is editorial copy rather than a config change. #254 stays open for it, along with the 118-character homepage title.

## Verification

Checked all **23** built pages programmatically, not by eye:

- `og:url` **equals** the canonical on every page
- `og:title` **equals** `<title>` on every page
- zero `http://sweetalert2` URLs remain anywhere
- exactly **1** `rel="icon"` link per page (confirming the dedupe)
- `bun run lint` and `bun run build` pass

Spot-check of a recipe page, which previously claimed to be the homepage:

```html
<meta property="og:title" content="Colored Toasts" />
<meta property="og:url" content="https://sweetalert2.github.io/recipe-gallery/colored-toasts.html" />
```

Worth validating once deployed, since neither tool can read a local build: [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) and [Twitter Card Validator](https://cards-dev.twitter.com/validator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
