### PR TITLE
perf: add resource hints for third-party origins

### DIFF
--- a/partials/head.html
+++ b/partials/head.html
@@ -8,6 +8,25 @@
   <link rel="icon" type="image/png" href="/images/favicon.png" />
   <link rel="apple-touch-icon" href="/images/favicon.png" />
 
+  <!--
+    Resource hints. jsdelivr gets a full preconnect because it serves two
+    render-blocking stylesheets below, so its connection is on the critical
+    path. Deliberately no crossorigin: the stylesheet requests are not CORS,
+    and a crossorigin preconnect would open a connection they cannot reuse.
+
+    The rest only get dns-prefetch. They are either deferred (analytics),
+    fetched after mount (the GitHub/npm stats in Header.tsx, the stars
+    iframe), or may never be used at all (Algolia, which requests only once
+    someone types in the search box), so spending a connection up front
+    would be wasteful.
+  -->
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+  <link rel="dns-prefetch" href="https://38BPOKYOZ2-dsn.algolia.net" />
+  <link rel="dns-prefetch" href="https://analytics.limonte.dev" />
+  <link rel="dns-prefetch" href="https://api.github.com" />
+  <link rel="dns-prefetch" href="https://api.npmjs.org" />
+  <link rel="dns-prefetch" href="https://ghbtns.com" />
+
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="SweetAlert2" />


### PR DESCRIPTION
Part of #259 — the resource-hints item. (Its minify item is [withdrawn](https://github.com/sweetalert2/sweetalert2.github.io/issues/259#issuecomment-5190017019); the jsdelivr-removal and Sandpack items remain.)

## Problem

The head referenced six third-party origins with no `preconnect` or `dns-prefetch`, so each paid a full DNS + TCP + TLS handshake on first use — including `cdn.jsdelivr.net`, which serves two **render-blocking** stylesheets and therefore gates first paint.

## Changes

**`preconnect` to `cdn.jsdelivr.net`** — the only origin on the critical path.

Deliberately **without** `crossorigin`. This matters: the two stylesheet requests are not CORS, and a `crossorigin` preconnect opens a separate connection they cannot reuse — a common way to make a preconnect silently useless.

**`dns-prefetch` for the other five** — Algolia (`38BPOKYOZ2-dsn.algolia.net`), `analytics.limonte.dev`, `api.github.com`, `api.npmjs.org`, `ghbtns.com`.

These are deferred, fetched after mount, or may never be used at all — Algolia only issues a request once someone types in the search box. Spending a full connection up front on those would be wasteful, and preconnect is a limited budget: hinting everything is self-defeating.

Hints are emitted **before** the stylesheets they help, which is what makes them effective at all.

## Known tradeoff

The head partial is shared by all 23 pages, but `api.github.com`, `api.npmjs.org` and `ghbtns.com` are only used by `Header.tsx`, which renders on the homepage alone. So the 22 other pages carry three hints they don't need.

I left it that way on purpose: `dns-prefetch` costs a DNS lookup and no connection, and per-page hint lists would mean threading another param through the shared partial for a negligible gain. Flagging it rather than pretending it's optimal.

## Verification

- Hints appear at lines 25–30 of the built HTML; the render-blocking stylesheets at 56 and 59. Ordering confirmed, not assumed.
- Every hinted origin is genuinely referenced in source — checked each one, no dead hints.
- All **23** pages carry the hints.
- `bun run lint` and `bun run build` pass.

The real win on this origin is deleting it: font-awesome 4 is EOL and pulls a whole icon webfont for `fa-bars` and `fa-arrow-left`, and animate.css is loaded for two keyframes. That's still open in #259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
