### PR TITLE
perf: declare intrinsic dimensions on unsized images

### DIFF
--- a/recipe-gallery/sweetalert2-laravel.tsx
+++ b/recipe-gallery/sweetalert2-laravel.tsx
@@ -96,7 +96,9 @@ Swal::toastQuestion([
         <img
           src="https://github.com/sweetalert2/sweetalert2-laravel/raw/main/sweetalert2-laravel.png"
           alt="SweetAlert2 Laravel integration demo screenshot"
-          style={{ maxWidth: 840 }}
+          width={1806}
+          height={776}
+          style={{ maxWidth: 840, height: 'auto' }}
           loading="lazy"
           decoding="async"
         />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -156,7 +156,7 @@ export function Header() {
             </div>
           </div>
         </div>
-        <img id="logo-text" src="./images/SweetAlert2.png" alt="SweetAlert2" />
+        <img id="logo-text" src="./images/SweetAlert2.png" alt="SweetAlert2" width={780} height={152} />
         <div className="stats mobile-hidden">
           <CurrentVersion />
           <LatestUpdate />

--- a/src/components/Showcase.tsx
+++ b/src/components/Showcase.tsx
@@ -12,7 +12,7 @@ export function Showcase() {
       </div>
 
       <div className="showcase sweet">
-        <img src="/images/SweetAlert2.png" height="30" alt="SweetAlert2" />
+        <img src="/images/SweetAlert2.png" width="154" height="30" alt="SweetAlert2" />
         <button
           className="show-example-btn"
           aria-label="Show SweetAlert2 success message"

--- a/src/components/Themes.tsx
+++ b/src/components/Themes.tsx
@@ -22,6 +22,7 @@ export function Themes() {
                   src="/images/themes-dark.png"
                   alt="SweetAlert2 Dark Theme"
                   width={300}
+                  height={143}
                   style={{ marginTop: 10 }}
                   loading="lazy"
                   decoding="async"

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -872,6 +872,11 @@ $bouncing-logo-min-height: 35%;
 #logo-text {
   width: 28em;
   max-width: 95%;
+
+  // The width/height attributes give the browser the aspect ratio up front so
+  // it can reserve space before the image loads. height must be auto or the
+  // height attribute would fight the CSS width and squash the logo.
+  height: auto;
 }
 
 .recipes-list {


### PR DESCRIPTION
Part of #258 — the CLS item, scoped to the images that genuinely lack an aspect ratio. (Per [my correction on the issue](https://github.com/sweetalert2/sweetalert2.github.io/issues/258#issuecomment-5190124344), 44 of 59 images already have both dimensions fixed in CSS and contribute no CLS.)

## Changes

| Image | Had | Added |
|---|---|---|
| `Header.tsx` `#logo-text` | CSS `width: 28em`, no height | `width={780} height={152}` + `height: auto` in SCSS |
| `Showcase.tsx` logo | `height="30"`, no width | `width="154"` |
| `Themes.tsx` dark screenshot | `width={300}`, no height | `height={143}` |
| laravel screenshot | inline `maxWidth: 840`, no height | `width={1806} height={776}` + `height: 'auto'` |

Two of the four are above the fold, where a shift is most visible.

## The `height: auto` part is load-bearing

For the two images whose width is constrained — `#logo-text` by CSS `width: 28em`, the laravel shot by `max-width: 840` — adding both dimension attributes **without** `height: auto` would make the height attribute fight the constrained width and squash the image. That's the trap in this kind of change, and it's why this wasn't a mechanical attribute sweep.

The other two aren't width-constrained by CSS, so their attributes simply set the rendered box, as `height="30"` and `width={300}` already did.

## Deliberately untouched

- **The 10 `.theme-comparison` images** — CSS already sets `width: 100%; height: 100%; object-fit: contain` on them. With both dimensions given in CSS, no aspect ratio is inferred from attributes, so adding them would be inert.
- **`logo-donut-track.svg`** — has only a `viewBox`, no intrinsic size, and drives a keyframe animation. Risk outweighs the benefit on a decorative `alt=""` image.

## Verification

Dimensions were **measured** (`sips`, and `curl` for the remote laravel image), not guessed. Every declared ratio matches the true intrinsic ratio:

```
image                true ratio  declared     err   constraint      height:auto
Header #logo-text        5.1316    5.1316   0.00%   CSS width:28em  yes   OK
Showcase logo            5.1316    5.1333   0.03%   attrs only      n/a   OK
Themes dark              2.0930    2.0979   0.23%   attrs only      n/a   OK
laravel shot             2.3273    2.3273   0.00%   max-width:840   yes   OK
```

The two sub-0.25% errors come from rounding the scaled dimension to a whole pixel — sub-pixel, so no visible distortion.

`bun run lint` and `bun run build` pass.

**Caveat worth stating:** this is verified by measurement and CSS reasoning, not by rendering. The repo has no visual-regression tooling, so a quick look at the header logo and the Themes table after deploy is worthwhile.

## Remaining in #258

WebP/AVIF conversion — `public/images/` is 1.3 MB, mostly `sponsors/` at 488 KB across 40 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
