### PR TITLE
perf: bundle animate.css instead of loading it from a CDN

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.0",
+        "animate.css": "^4.1.1",
         "oxfmt": "^0.59.0",
         "oxlint": "^1.51.0",
         "sass": "^1.97.3",
@@ -337,6 +338,8 @@
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.3", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "animate.css": ["animate.css@4.1.1", "", {}, "sha512-+mRmCTv6SbCmtYJCN4faJMNFVNN5EuCTTprDTAo7YzIGji2KADmakjVA3+8mVDkZ2Bf09vayB35lSQIex2+QaQ=="],
 
     "anser": ["anser@2.3.5", "", {}, "sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ=="],
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.0",
+    "animate.css": "^4.1.1",
     "oxfmt": "^0.59.0",
     "oxlint": "^1.51.0",
     "sass": "^1.97.3",

--- a/partials/head.html
+++ b/partials/head.html
@@ -54,9 +54,6 @@
   <!-- Font Awesome icons -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4/css/font-awesome.min.css" />
 
-  <!-- Animate.css -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/animate.css@4/animate.min.css" />
-
   <script
     defer
     src="https://analytics.limonte.dev/script.js"

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -2,6 +2,9 @@
 @use 'sass:color';
 @use '/node_modules/@docsearch/css/dist/style.css';
 @use '/node_modules/highlight.js/styles/atom-one-dark.css';
+// Bundled instead of loaded from a CDN: 5 KB gzipped, and it removes a
+// render-blocking third-party stylesheet from the critical path.
+@use '/node_modules/animate.css/animate.min.css';
 @use '../public/bootstrap4-buttons.css';
 
 @import '@fontsource/montserrat/latin-400.css';


### PR DESCRIPTION
Part of #259 — removes one of the two render-blocking third-party stylesheets.

## Changes

- `animate.css` added as a devDependency and `@use`d from `styles/styles.scss`, the same way `@docsearch/css` and highlight.js styles are already imported there
- the CDN `<link>` dropped from `partials/head.html`

**4 files, +7 / −3.**

## Why import the package rather than extract the 9 keyframes

The issue suggested copying the keyframes the site actually uses into `styles.scss`. I measured first: the full published `animate.min.css` is **5.2 KB gzipped**. Against a 15 KB CSS bundle that's cheap enough that hand-copying isn't worth its downsides — extracted CSS silently drifts from upstream and has to be re-checked by hand on every update. Importing the real package means the definitions are upstream's, and Renovate keeps them current.

Note the `source/` files in the package can't be used directly: they carry unprefixed class names (`.fadeInLeft`), because the `animate__` prefix is applied at the package's build step. Only the published file has the `.animate__fadeInLeft` selectors this site's markup depends on.

## Cost

CSS bundle: **14,967 → 20,833 bytes gzipped** (+5.9 KB).

Good trade for eliminating a blocking third-party request — a cold connection costs far more than 5.9 KB of same-origin, already-cached-with-everything-else CSS.

## Verification

- The CDN `animate.css` link is gone from **all 23** built pages.
- All **9** animations the site uses resolve to real rules in the bundled CSS — `fadeIn`/`fadeOut` × `Left`/`Right`/`Up`/`Down` plus `headShake` — each matched as an exact `^\.animate__X \{` rule, not a substring (`animate__fadeInLeft` would otherwise match `animate__fadeInLeftBig`).
- `.animate__animated`, `.animate__faster` and the `:root { --animate-duration }` custom property they depend on are all present.
- Spot-checked that `.animate__headShake` is wired to a defined `@keyframes headShake`.
- `bun run lint` and `bun run build` pass.

Affected UI: the sidebar drawer (`src/utils/sidebar.tsx`) and the sidebars-drawers and draw-attention recipes. Worth opening the sidebar once after deploy to confirm it still slides.

## Still open in #259

**font-awesome 4 still loads from jsdelivr**, so the origin remains on the critical path and its `preconnect` (#267) is still earned. Removing it means replacing 7 icons — `fa-bars`, `fa-arrow-left`, `fa-arrow-right`, `fa-external-link`, `fa-info-circle`, `fa-thumbs-up`, `fa-thumbs-down` — with inline SVG. That's the larger half, and it's what finally takes jsdelivr off the critical path. Lazy-mounting Sandpack also remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
