### PR TITLE
perf: replace Font Awesome with inline SVG icons

### DIFF
--- a/partials/head.html
+++ b/partials/head.html
@@ -9,18 +9,13 @@
   <link rel="apple-touch-icon" href="/images/favicon.png" />
 
   <!--
-    Resource hints. jsdelivr gets a full preconnect because it serves two
-    render-blocking stylesheets below, so its connection is on the critical
-    path. Deliberately no crossorigin: the stylesheet requests are not CORS,
-    and a crossorigin preconnect would open a connection they cannot reuse.
-
-    The rest only get dns-prefetch. They are either deferred (analytics),
-    fetched after mount (the GitHub/npm stats in Header.tsx, the stars
-    iframe), or may never be used at all (Algolia, which requests only once
-    someone types in the search box), so spending a connection up front
-    would be wasteful.
+    Resource hints. Nothing here is on the critical path any more now that no
+    stylesheet is loaded from a third party, so there is no preconnect: these
+    origins are all either deferred (analytics), fetched after mount (the
+    GitHub/npm stats in Header.tsx, the stars iframe), or may never be used at
+    all (Algolia, which requests only once someone types in the search box).
+    dns-prefetch covers the DNS lookup without spending a connection up front.
   -->
-  <link rel="preconnect" href="https://cdn.jsdelivr.net" />
   <link rel="dns-prefetch" href="https://38BPOKYOZ2-dsn.algolia.net" />
   <link rel="dns-prefetch" href="https://analytics.limonte.dev" />
   <link rel="dns-prefetch" href="https://api.github.com" />
@@ -50,9 +45,6 @@
   <meta name="theme-color" content="#f2f4f6" />
 
   <link rel="stylesheet" href="/styles/styles.scss" />
-
-  <!-- Font Awesome icons -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4/css/font-awesome.min.css" />
 
   <script
     defer

--- a/src/components/Examples.tsx
+++ b/src/components/Examples.tsx
@@ -1,5 +1,6 @@
 import { examples } from '../examples'
 import { CodeExample } from './CodeExample'
+import { IconExternalLink } from './UiIcons'
 
 export function Examples() {
   return (
@@ -132,7 +133,7 @@ export function Examples() {
                 tabIndex={-1}
                 className="nowrap"
               >
-                Animate.css <i className="fa fa-external-link"></i>
+                Animate.css <IconExternalLink />
               </a>
             </p>
             <button

--- a/src/components/Installation.tsx
+++ b/src/components/Installation.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { CodeExample } from './CodeExample'
 import { CodeWithCopy } from './CodeWithCopy'
+import { IconExternalLink } from './UiIcons'
 
 export function Installation() {
   return (
@@ -15,7 +16,7 @@ export function Installation() {
         <p>
           Or grab from{' '}
           <a href="https://www.jsdelivr.com/package/npm/sweetalert2" target="_blank" rel="noopener" className="nowrap">
-            jsDelivr CDN <i className="fa fa-external-link"></i>
+            jsDelivr CDN <IconExternalLink />
           </a>
         </p>
         <CodeExample

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -2,6 +2,7 @@ import Swal from 'sweetalert2'
 import { showSidebar } from '../utils'
 import { DocSearch } from './DocSearch'
 import { ThemeSelector } from '../utils/themableSwal'
+import { IconArrowLeft, IconBars } from './UiIcons'
 
 export const sidebarUrl = 'https://github.com/sweetalert2/sweetalert2.github.io/blob/main/src/utils/sidebar.tsx'
 
@@ -16,7 +17,7 @@ export function Nav({
     <>
       <Sidebar />
       <button className="show-sidebar" onClick={() => showSidebar()} aria-label="Open navigation menu">
-        <i className="fa fa-bars" aria-hidden="true"></i>
+        <IconBars />
       </button>
 
       {recipeGallery ? (
@@ -24,7 +25,7 @@ export function Nav({
           <div className="recipe-gallery-top-nav">
             {showBackToRecipeGalleryLink ? (
               <a href="/recipe-gallery/">
-                <i className="fa fa-arrow-left"></i> Back to Recipe Gallery
+                <IconArrowLeft /> Back to Recipe Gallery
               </a>
             ) : null}
             <DocSearch />

--- a/src/components/UiIcons.tsx
+++ b/src/components/UiIcons.tsx
@@ -1,0 +1,50 @@
+// Inline replacements for the handful of Font Awesome 4 icons this site used
+// for its own chrome. FA4 is EOL and pulled a whole icon webfont from a CDN for
+// three glyphs. These size off the inherited font-size and inherit text colour.
+//
+// All are decorative: every call site has adjacent text or its own aria-label,
+// so they are hidden from assistive tech.
+
+const decorative = {
+  'width': '1em',
+  'height': '1em',
+  'aria-hidden': true,
+  'focusable': 'false',
+} as const
+
+const stroke = {
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 2,
+  strokeLinecap: 'round',
+  strokeLinejoin: 'round',
+} as const
+
+export function IconBars() {
+  return (
+    <svg {...decorative} className="ui-icon" viewBox="0 0 24 24" fill="currentColor">
+      <rect x="3" y="5" width="18" height="2" rx="1" />
+      <rect x="3" y="11" width="18" height="2" rx="1" />
+      <rect x="3" y="17" width="18" height="2" rx="1" />
+    </svg>
+  )
+}
+
+export function IconArrowLeft() {
+  return (
+    <svg {...decorative} className="ui-icon" viewBox="0 0 24 24" {...stroke}>
+      <path d="M19 12H5" />
+      <path d="m12 19-7-7 7-7" />
+    </svg>
+  )
+}
+
+export function IconExternalLink() {
+  return (
+    <svg {...decorative} className="ui-icon" viewBox="0 0 24 24" {...stroke}>
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+      <path d="M15 3h6v6" />
+      <path d="M10 14 21 3" />
+    </svg>
+  )
+}

--- a/src/examples/functions.ts
+++ b/src/examples/functions.ts
@@ -57,11 +57,11 @@ export default {
       showCancelButton: true,
       focusConfirm: false,
       confirmButtonText: `
-        <i class="fa fa-thumbs-up"></i> Great!
+        👍 Great!
       `,
       confirmButtonAriaLabel: 'Thumbs up, great!',
       cancelButtonText: `
-        <i class="fa fa-thumbs-down"></i>
+        👎
       `,
       cancelButtonAriaLabel: 'Thumbs down',
     })
@@ -454,7 +454,7 @@ export default {
         I agree with the terms and conditions
       `,
       confirmButtonText: `
-        Continue&nbsp;<i class="fa fa-arrow-right"></i>
+        Continue&nbsp;→
       `,
       inputValidator: (result) => {
         return !result && 'You need to agree with T&C'

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -639,6 +639,13 @@ tr:hover {
   white-space: nowrap;
 }
 
+// Inline UI icons (src/components/UiIcons.tsx). Sized in em so they scale with
+// the inherited font-size, nudged down to sit on the text baseline the way the
+// Font Awesome glyphs they replaced did.
+.ui-icon {
+  vertical-align: -0.125em;
+}
+
 .border-radius-0 {
   border-radius: 0 !important;
 }


### PR DESCRIPTION
Part of #259. With animate.css bundled in #270, this removes the **last third-party stylesheet from the critical path**.

Font Awesome 4 is EOL (last release 2016) and was fetched from jsdelivr as a render-blocking stylesheet, which then pulled a whole icon webfont, to draw **3 glyphs** of site chrome.

## Changes

**`src/components/UiIcons.tsx`** (new) — `IconBars`, `IconArrowLeft`, `IconExternalLink` as inline SVG. Sized in `em` so they scale with the inherited `font-size` (`.show-sidebar` sets `1.8em`, and the icon follows), and they inherit text colour via `currentColor`.

All three are decorative and `aria-hidden` — every call site either has adjacent text ("Back to Recipe Gallery", "jsDelivr CDN") or its own `aria-label` (the menu button). So nothing is lost for assistive tech.

**`.ui-icon`** in `styles.scss` nudges them onto the text baseline where the webfont glyphs sat (`vertical-align: -0.125em`).

**Example code uses emoji instead.** The three remaining icons live in `src/examples/functions.ts`, whose source is stringified and **displayed verbatim as the documentation** (see the minify finding on this issue). Inlining SVG path data there would wreck those snippets, so:

```diff
-confirmButtonText: `<i class="fa fa-thumbs-up"></i> Great!`
+confirmButtonText: `👍 Great!`
-Continue&nbsp;<i class="fa fa-arrow-right"></i>
+Continue&nbsp;→
```

Existing `confirmButtonAriaLabel` / `cancelButtonAriaLabel` values are unchanged, so the buttons keep their accessible names. **This is the one visible content change in the PR** — the thumbs-up/down and arrow in the "custom HTML" and T&C examples now render as emoji.

**Removed** the `font-awesome` `<link>` and, with it, the jsdelivr `preconnect` added in #267 — nothing loads from that origin any more, so the hint was dead weight.

## Verification

- **0** of 23 pages reference `font-awesome` or `jsdelivr`.
- The only `<link rel="stylesheet">` left in the head is same-origin: `/assets/components-*.css`.
- Remaining external origins are `analytics.limonte.dev` (deferred), `api.github.com` / `api.npmjs.org` / `ghbtns.com` (after mount), and Algolia (on demand) — all `dns-prefetch` only, none blocking.
- All three icon components are in the bundle with their path data intact, and `.ui-icon` is in the emitted CSS.
- No `fa fa-` class remains in the JS bundle.
- `bun run lint` and `bun run build` pass.

## Left alone deliberately

`recipe-gallery/validation-message-custom-icon-src.tsx:12` still uses `fa-info-circle`. That runs inside **Sandpack**, which only ever injects `sweetalert2` plus per-recipe deps and never had Font Awesome — so that icon was already not rendering in its own preview. Pre-existing, unaffected by this change, and fixing it means rewriting a recipe whose subject *is* custom icons. Worth its own issue.

## Worth a look after deploy

The mobile hamburger button, the "Back to Recipe Gallery" link, the two external-link icons, and the two affected examples on the homepage. This is verified by build output and CSS reasoning, not by rendering.

## Still open in #259

Lazy-mounting Sandpack (1.17 MB / 317 KB gzipped on every recipe page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
