### PR TITLE
feat: show a breadcrumb trail on recipe pages

### DIFF
--- a/recipe-gallery/index.tsx
+++ b/recipe-gallery/index.tsx
@@ -4,7 +4,7 @@ import { renderRecipe } from '../src/utils'
 function Recipe() {
   return (
     <>
-      <Nav recipeGallery showBackToRecipeGalleryLink={false} />
+      <Nav recipeGallery showBreadcrumbs={false} />
       <h1>Recipe Gallery</h1>
       <p className="center">
         A collection of easy-to-digest code examples for specific tasks in about 30 lines of code or less.

--- a/src/404.tsx
+++ b/src/404.tsx
@@ -5,7 +5,7 @@ function NotFound() {
   return (
     <>
       {/* recipeGallery renders the top nav with the search box; there is no gallery to go back to */}
-      <Nav recipeGallery showBackToRecipeGalleryLink={false} />
+      <Nav recipeGallery showBreadcrumbs={false} />
 
       <h1>Page not found</h1>
 

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -2,16 +2,16 @@ import Swal from 'sweetalert2'
 import { showSidebar } from '../utils'
 import { DocSearch } from './DocSearch'
 import { ThemeSelector } from '../utils/themableSwal'
-import { IconArrowLeft, IconBars } from './UiIcons'
+import { IconBars } from './UiIcons'
 
 export const sidebarUrl = 'https://github.com/sweetalert2/sweetalert2.github.io/blob/main/src/utils/sidebar.tsx'
 
 export function Nav({
   recipeGallery = false,
-  showBackToRecipeGalleryLink = true,
+  showBreadcrumbs = true,
 }: {
   recipeGallery?: boolean
-  showBackToRecipeGalleryLink?: boolean
+  showBreadcrumbs?: boolean
 }) {
   return (
     <>
@@ -23,10 +23,17 @@ export function Nav({
       {recipeGallery ? (
         <>
           <div className="recipe-gallery-top-nav">
-            {showBackToRecipeGalleryLink ? (
-              <a href="/recipe-gallery/">
-                <IconArrowLeft /> Back to Recipe Gallery
-              </a>
+            {showBreadcrumbs ? (
+              // Mirrors the BreadcrumbList JSON-LD the generator emits: Google
+              // prefers breadcrumb markup to match a visible trail. The current
+              // page is the <h1> below, so it is not repeated here.
+              <nav className="breadcrumbs" aria-label="Breadcrumb">
+                <a href="/">SweetAlert2</a>
+                <span className="separator" aria-hidden="true">
+                  /
+                </span>
+                <a href="/recipe-gallery/">Recipe Gallery</a>
+              </nav>
             ) : null}
             <DocSearch />
           </div>

--- a/src/components/UiIcons.tsx
+++ b/src/components/UiIcons.tsx
@@ -30,15 +30,6 @@ export function IconBars() {
   )
 }
 
-export function IconArrowLeft() {
-  return (
-    <svg {...decorative} className="ui-icon" viewBox="0 0 24 24" {...stroke}>
-      <path d="M19 12H5" />
-      <path d="m12 19-7-7 7-7" />
-    </svg>
-  )
-}
-
 export function IconExternalLink() {
   return (
     <svg {...decorative} className="ui-icon" viewBox="0 0 24 24" {...stroke}>

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -903,15 +903,23 @@ $bouncing-logo-min-height: 35%;
   align-items: center;
   justify-content: center;
 
-  @media all and (width > 768px) {
-    a {
+  // The offset belongs to the trail as a whole, not to each link inside it,
+  // so it stays on .breadcrumbs rather than on a bare `a` selector.
+  .breadcrumbs {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+
+    @media all and (width > 768px) {
       margin-right: 20em;
     }
-  }
 
-  @media all and (width <= 768px) {
-    a {
+    @media all and (width <= 768px) {
       margin-top: 1em;
+    }
+
+    .separator {
+      color: $chateaugray;
     }
   }
 


### PR DESCRIPTION
Closes the caveat left on #255 and the "no breadcrumbs / weak internal linking" point in #256.

## Why

#265 added `BreadcrumbList` JSON-LD to all 21 recipe pages, but Google prefers that markup to correspond to a **visible** trail. Recipe pages only had a "← Back to Recipe Gallery" link — not a trail, and it gave no route to the homepage.

## Changes

`Nav` now renders, on recipe pages:

```
SweetAlert2 / Recipe Gallery
```

as `<nav aria-label="Breadcrumb">`. The current page isn't repeated in the trail because it's the `<h1>` immediately below — the JSON-LD still carries all three levels, which is the normal pairing.

- **`showBackToRecipeGalleryLink` → `showBreadcrumbs`** (2 call sites). The gallery index and the 404 page still pass `false`, so **their layout is unchanged** — a lone "SweetAlert2" crumb would have added nothing there and would have shifted their centred search box.
- **The centring offset moved from a bare `a` selector onto `.breadcrumbs`.** This one matters: `.recipe-gallery-top-nav a { margin-right: 20em }` existed to keep the search box centred against a single back-link. With two links in the trail it would have applied to *each*, pushing the search box off-screen.
- **`IconArrowLeft` deleted** — added in #271 for the back-arrow, now unused. Removing it rather than leaving dead code.

## Verification

- Visible trail matches the JSON-LD exactly: markup names are `['SweetAlert2', 'Recipe Gallery', 'Colored Toasts']`, and the visible trail is `SweetAlert2 / Recipe Gallery` plus the `<h1>` as the current page.
- `.recipe-gallery-top-nav .breadcrumbs { margin-right: 20em }` is in the emitted CSS and the old bare-`a` rule is gone — confirmed by grepping the built stylesheet, since that was the layout-regression risk.
- Separator is `aria-hidden`, so screen readers hear the two links without the slash.
- No `IconArrowLeft` reference remains anywhere.
- `bun run lint` and `bun run build` pass.

## Side benefit

Every recipe page now links to the homepage as well as the gallery, which is the internal-linking weakness #256 called out — 21 pages previously linked only sideways to the gallery.

## Worth a look after deploy

The top nav on any recipe page at desktop and mobile widths, since the search-box centring depends on that moved margin. Verified by CSS reasoning, not by rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
