### PR TITLE
fix: drop the dead font-awesome CodePen stylesheet

### DIFF
--- a/src/components/Examples.tsx
+++ b/src/components/Examples.tsx
@@ -88,10 +88,7 @@ export function Examples() {
               Try me!
             </button>
           </div>
-          <CodeExample
-            code={examples.customHtml.fnString}
-            codepenCssExternal="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css"
-          />
+          <CodeExample code={examples.customHtml.fnString} />
         </li>
 
         <li id="three-buttons">


### PR DESCRIPTION
Leftover from #271.

That PR changed the `customHtml` example's buttons from `fa-thumbs-up` / `fa-thumbs-down` to emoji, but left `codepenCssExternal` on the matching `<CodeExample>` pointing at font-awesome. So "Edit in CodePen" still injected a stylesheet the pen no longer used.

```diff
-          <CodeExample
-            code={examples.customHtml.fnString}
-            codepenCssExternal="https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css"
-          />
+          <CodeExample code={examples.customHtml.fnString} />
```

**The other two `codepenCssExternal` values stay**, since their pens genuinely need them: `animate.css` for the `customAnimation` example (bundling it in #270 covers this site, not an exported pen) and `bootstrap4-buttons.css` for the bootstrap example.

Verified: **0** font-awesome references remain in the JS bundle; both other external stylesheets are still emitted. `bun run lint` and `bun run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
